### PR TITLE
[feat:#10] 공연 정보 조회 코드 구현

### DIFF
--- a/ticket/src/main/java/comento/backend/ticket/config/GlobalExceptionHandler.java
+++ b/ticket/src/main/java/comento/backend/ticket/config/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -26,10 +27,14 @@ public class GlobalExceptionHandler {
      */
 
     //ConstraintViolationException.class 는 유효성 검사 실패시 (@Validated)
-    @ExceptionHandler({JsonParseException.class, MethodArgumentNotValidException.class, ConstraintViolationException.class, MethodArgumentTypeMismatchException.class})
+    @ExceptionHandler({JsonParseException.class,
+            MethodArgumentNotValidException.class,
+                    ConstraintViolationException.class,
+            MethodArgumentTypeMismatchException.class,
+            MissingServletRequestParameterException.class})
     public static ResponseEntity missMatchExceptionHandler(Throwable t){
         errorCode = ErrorCode.INVALID_VALUE;
-        log.error(errorCode.getStatus() + errorCode.getMessage(), t);
+        log.error(errorCode.getStatus() + " " + errorCode.getMessage(), t);
         return new ResponseEntity<>(ErrorResponse.res(errorCode.getStatus(), errorCode.getMessage(), errorCode.getReason()),
                 errorCode.getHttpStatus());
     }
@@ -45,7 +50,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({NoSuchElementException.class, NotFoundException.class, NotFoundDataException.class})
     public static ResponseEntity notFoundExceptionHandler(Throwable t){
         errorCode = ErrorCode.NO_DATA;
-        log.error(errorCode.getStatus()+ " " + errorCode.getMessage(), t);
+        log.error(errorCode.getStatus() + " " + errorCode.getMessage(), t);
         return new ResponseEntity<>(ErrorResponse.res(errorCode.getStatus(), errorCode.getMessage(), errorCode.getReason()),
                 errorCode.getHttpStatus());
     }
@@ -54,10 +59,10 @@ public class GlobalExceptionHandler {
     public static ResponseEntity duplicateExceptionHandler(DuplicatedException e){
         if (e.getMessage() == "UserService") { //호출된 곳이 UserService
             errorCode = ErrorCode.INVALID_USER;
-            log.error(errorCode.getStatus()+ " " + errorCode.getMessage(), e);
+            log.error(errorCode.getStatus() + " " + errorCode.getMessage(), e);
         }else{ //좌석 예약 시
             errorCode = ErrorCode.INVALID_SEAT;
-            log.error(errorCode.getStatus()+ " " + errorCode.getMessage(), e);
+            log.error(errorCode.getStatus() + " " + errorCode.getMessage(), e);
         }
         return new ResponseEntity<>(ErrorResponse.res(errorCode.getStatus(), errorCode.getMessage(), errorCode.getReason()),
                 errorCode.getHttpStatus());
@@ -66,7 +71,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({IllegalStateException.class, RuntimeException.class})
     public static ResponseEntity IllExceptionHandler(Throwable t){
         errorCode = ErrorCode.SERVER_ERROR;
-        log.error(errorCode.getStatus()+ " " + errorCode.getMessage(), t);
+        log.error(errorCode.getStatus() + " " + errorCode.getMessage(), t);
         return new ResponseEntity<>(ErrorResponse.res(errorCode.getStatus(), errorCode.getMessage(), errorCode.getReason()),
                 errorCode.getHttpStatus());
     }

--- a/ticket/src/main/java/comento/backend/ticket/controller/PerformanceController.java
+++ b/ticket/src/main/java/comento/backend/ticket/controller/PerformanceController.java
@@ -1,0 +1,52 @@
+package comento.backend.ticket.controller;
+
+import comento.backend.ticket.config.SuccessCode;
+import comento.backend.ticket.config.SuccessResponse;
+import comento.backend.ticket.config.customException.NotFoundDataException;
+import comento.backend.ticket.domain.Performance;
+import comento.backend.ticket.dto.PerformanceDto;
+import comento.backend.ticket.service.PerformanceService;
+import comento.backend.ticket.service.SeatService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.util.*;
+import java.util.Date;
+
+@RestController
+@RequestMapping("/api/performance")
+public class PerformanceController {
+    private final PerformanceService performanceService;
+    private final SeatService seatService;
+    private SuccessCode successCode = SuccessCode.OK;
+
+    @Autowired
+    public PerformanceController(PerformanceService performanceService, SeatService seatService) {
+        this.performanceService = performanceService;
+        this.seatService = seatService;
+    }
+
+    @GetMapping("/info")
+    public ResponseEntity showPerformanceInfo(@Valid @RequestParam(value = "date", required = true)
+                                                  @DateTimeFormat(pattern = "yyyy-MM-dd") Date date,
+                                              @Valid @RequestParam(value = "title", required = false) String title) {
+        PerformanceDto performanceDto = new PerformanceDto(title, date);
+        List<Performance> result;
+        result = performanceDto.getTitle() != null ?
+                performanceService.getListByDateAndTitle(performanceDto) : performanceService.getListByDate(performanceDto);
+
+        if(result.isEmpty()){
+            throw new NotFoundDataException();
+        }
+
+        return new ResponseEntity(SuccessResponse.res(successCode.getStatus(), successCode.getMessage(), result),
+                HttpStatus.OK);
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/controller/PerformanceController.java
+++ b/ticket/src/main/java/comento/backend/ticket/controller/PerformanceController.java
@@ -2,9 +2,9 @@ package comento.backend.ticket.controller;
 
 import comento.backend.ticket.config.SuccessCode;
 import comento.backend.ticket.config.SuccessResponse;
-import comento.backend.ticket.config.customException.NotFoundDataException;
 import comento.backend.ticket.domain.Performance;
 import comento.backend.ticket.dto.PerformanceDto;
+import comento.backend.ticket.dto.PerformanceResponse;
 import comento.backend.ticket.service.PerformanceService;
 import comento.backend.ticket.service.SeatService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +19,8 @@ import org.springframework.web.bind.annotation.RestController;
 import javax.validation.Valid;
 import java.util.*;
 import java.util.Date;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @RestController
 @RequestMapping("/api/performance")
@@ -38,13 +40,7 @@ public class PerformanceController {
                                                   @DateTimeFormat(pattern = "yyyy-MM-dd") Date date,
                                               @Valid @RequestParam(value = "title", required = false) String title) {
         PerformanceDto performanceDto = new PerformanceDto(title, date);
-        List<Performance> result;
-        result = performanceDto.getTitle() != null ?
-                performanceService.getListByDateAndTitle(performanceDto) : performanceService.getListByDate(performanceDto);
-
-        if(result.isEmpty()){
-            throw new NotFoundDataException();
-        }
+        List<PerformanceResponse> result = performanceService.getListPerformance(performanceDto);
 
         return new ResponseEntity(SuccessResponse.res(successCode.getStatus(), successCode.getMessage(), result),
                 HttpStatus.OK);

--- a/ticket/src/main/java/comento/backend/ticket/domain/Performance.java
+++ b/ticket/src/main/java/comento/backend/ticket/domain/Performance.java
@@ -1,0 +1,55 @@
+package comento.backend.ticket.domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+import javax.persistence.*;
+import java.util.Date;
+
+@Entity
+@Data
+@Table(name="Performance")
+public class Performance {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="performance_id")
+    private Long id;
+
+    @Column
+    private String title;
+
+    @Column
+    private String genere;
+
+    @Column(name="start_date")
+    @Temporal(TemporalType.DATE)
+    private Date startDate;
+
+    @Column(name="end_date")
+    @Temporal(TemporalType.DATE)
+    private Date endDate;
+
+    @Column(columnDefinition = "TEXT")
+    private String price;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "running_time")
+    private String runningTime;
+
+    public Performance(){}
+
+    @Builder
+    public Performance(Long id, String title, String genere, Date startDate, Date endDate, String price, String description, String runningTime) {
+        this.id = id;
+        this.title = title;
+        this.genere = genere;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.price = price;
+        this.description = description;
+        this.runningTime = runningTime;
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/dto/PerformanceDto.java
+++ b/ticket/src/main/java/comento/backend/ticket/dto/PerformanceDto.java
@@ -1,0 +1,35 @@
+package comento.backend.ticket.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+
+@Getter
+@Setter
+public class PerformanceDto {
+    private String title;
+    private Date startDate;
+    private Date endDate;
+    private String price;
+    private String genere;
+    private String description;
+    private String runningTime;
+
+    public PerformanceDto(){}
+
+    public PerformanceDto(String title, Date startDate) {
+        this.title = title;
+        this.startDate = startDate;
+    }
+
+    public PerformanceDto(String title, Date startDate, Date endDate, String price, String genere, String description, String runningTime) {
+        this.title = title;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.price = price;
+        this.genere = genere;
+        this.description = description;
+        this.runningTime = runningTime;
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/dto/PerformanceResponse.java
+++ b/ticket/src/main/java/comento/backend/ticket/dto/PerformanceResponse.java
@@ -1,0 +1,43 @@
+package comento.backend.ticket.dto;
+
+import comento.backend.ticket.domain.Performance;
+import lombok.Data;
+
+import java.util.*;
+
+@Data
+public class PerformanceResponse {
+    private Long id;
+    private String title;
+    private Date startDate;
+    private Date endDate;
+    private String price;
+    private String genere;
+    private String description;
+    private String runningTime;
+
+    public PerformanceResponse(Long id, String title, Date startDate, Date endDate, String price, String genere, String description, String runningTime) {
+        this.id = id;
+        this.title = title;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.price = price;
+        this.genere = genere;
+        this.description = description;
+        this.runningTime = runningTime;
+    }
+
+    //convert
+    public static PerformanceResponse of(Performance performance){
+        return new PerformanceResponse(
+                performance.getId(),
+                performance.getTitle(),
+                performance.getStartDate(),
+                performance.getEndDate(),
+                performance.getPrice(),
+                performance.getGenere(),
+                performance.getDescription(),
+                performance.getRunningTime()
+        );
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/repository/PerformanceRepository.java
+++ b/ticket/src/main/java/comento/backend/ticket/repository/PerformanceRepository.java
@@ -9,7 +9,6 @@ import java.util.List;
 
 @Repository
 public interface PerformanceRepository extends JpaRepository<Performance, Long> {
-    //@TODO : 쿼리 다시 짜기!
     List<Performance> findByStartDateGreaterThanEqualOrderByStartDateAsc(Date startDate);
     List<Performance> findByTitleAndStartDateGreaterThanEqualOrderByStartDate(String title, Date startDate);
 }

--- a/ticket/src/main/java/comento/backend/ticket/repository/PerformanceRepository.java
+++ b/ticket/src/main/java/comento/backend/ticket/repository/PerformanceRepository.java
@@ -1,0 +1,15 @@
+package comento.backend.ticket.repository;
+
+import comento.backend.ticket.domain.Performance;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Date;
+import java.util.List;
+
+@Repository
+public interface PerformanceRepository extends JpaRepository<Performance, Long> {
+    //@TODO : 쿼리 다시 짜기!
+    List<Performance> findByStartDateGreaterThanEqualOrderByStartDateAsc(Date startDate);
+    List<Performance> findByTitleAndStartDateGreaterThanEqualOrderByStartDate(String title, Date startDate);
+}

--- a/ticket/src/main/java/comento/backend/ticket/service/PerformanceService.java
+++ b/ticket/src/main/java/comento/backend/ticket/service/PerformanceService.java
@@ -1,31 +1,33 @@
 package comento.backend.ticket.service;
 
+import comento.backend.ticket.config.customException.NotFoundDataException;
 import comento.backend.ticket.domain.Performance;
 import comento.backend.ticket.dto.PerformanceDto;
+import comento.backend.ticket.dto.PerformanceResponse;
 import comento.backend.ticket.repository.PerformanceRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Date;
+import java.util.stream.Collectors;
 
 @Service
 public class PerformanceService {
     private final PerformanceRepository performanceRepository;
 
-    @Autowired
     public PerformanceService(PerformanceRepository performanceRepository) {
         this.performanceRepository = performanceRepository;
     }
 
-    public List<Performance> getListByDate(PerformanceDto performanceDto){
-        Date startDate = performanceDto.getStartDate();
-        return performanceRepository.findByStartDateGreaterThanEqualOrderByStartDateAsc(startDate);
-    }
-
-    public List<Performance> getListByDateAndTitle(PerformanceDto performanceDto){
+    public List<PerformanceResponse> getListPerformance(PerformanceDto performanceDto){
         Date startDate = performanceDto.getStartDate();
         String title = performanceDto.getTitle();
-        return performanceRepository.findByTitleAndStartDateGreaterThanEqualOrderByStartDate(title, startDate);
+        List<Performance> result = title != null ?
+                performanceRepository.findByTitleAndStartDateGreaterThanEqualOrderByStartDate(title, startDate) :
+                performanceRepository.findByStartDateGreaterThanEqualOrderByStartDateAsc(startDate);
+        if(result.isEmpty()){
+            throw new NotFoundDataException();
+        }
+        return result.stream().map(PerformanceResponse::of).collect(Collectors.toList());
     }
 }

--- a/ticket/src/main/java/comento/backend/ticket/service/PerformanceService.java
+++ b/ticket/src/main/java/comento/backend/ticket/service/PerformanceService.java
@@ -1,0 +1,31 @@
+package comento.backend.ticket.service;
+
+import comento.backend.ticket.domain.Performance;
+import comento.backend.ticket.dto.PerformanceDto;
+import comento.backend.ticket.repository.PerformanceRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Date;
+
+@Service
+public class PerformanceService {
+    private final PerformanceRepository performanceRepository;
+
+    @Autowired
+    public PerformanceService(PerformanceRepository performanceRepository) {
+        this.performanceRepository = performanceRepository;
+    }
+
+    public List<Performance> getListByDate(PerformanceDto performanceDto){
+        Date startDate = performanceDto.getStartDate();
+        return performanceRepository.findByStartDateGreaterThanEqualOrderByStartDateAsc(startDate);
+    }
+
+    public List<Performance> getListByDateAndTitle(PerformanceDto performanceDto){
+        Date startDate = performanceDto.getStartDate();
+        String title = performanceDto.getTitle();
+        return performanceRepository.findByTitleAndStartDateGreaterThanEqualOrderByStartDate(title, startDate);
+    }
+}

--- a/ticket/src/test/java/comento/backend/ticket/repository/PerformanceRepositroyTest.java
+++ b/ticket/src/test/java/comento/backend/ticket/repository/PerformanceRepositroyTest.java
@@ -1,0 +1,72 @@
+package comento.backend.ticket.repository;
+
+import comento.backend.ticket.domain.Performance;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class PerformanceRepositroyTest {
+    private final PerformanceRepository performanceRepository;
+
+    @Autowired
+    public PerformanceRepositroyTest(PerformanceRepository performanceRepository) {
+        this.performanceRepository = performanceRepository;
+    }
+
+    @Test
+    @DisplayName("[성공] 날짜를 정확하게 입력한 경우")
+    public void 공연_날짜_정보_조회() throws ParseException {
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("2020-06-20");
+
+        List<Performance> result = performanceRepository.findByStartDateGreaterThanEqualOrderByStartDateAsc(startDate);
+
+        assertThat(result.size()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("[성공] 날짜, 공연제목을 정확하게 입력한 경우")
+    public void 공연_날짜이름_정보_조회() throws ParseException {
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("2020-06-20");
+        String title = "국립무용단 <산조>";
+
+        List<Performance> result = performanceRepository.findByTitleAndStartDateGreaterThanEqualOrderByStartDate(title, startDate);
+
+        assertThat(result.size()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("[실패] NOT FOUND ERROR")
+    public void 공연_날짜_정보_조회실패() throws ParseException {
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("2021-06-31");
+
+        List<Performance> result = performanceRepository.findByStartDateGreaterThanEqualOrderByStartDateAsc(startDate);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("[실패] BAD REQUEST")
+    public void 공연_날짜이름_정보_조회실패() throws ParseException {
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("ㄴ");
+        String title = "국립무용단 <산조>";
+
+        List<Performance> result = performanceRepository.findByTitleAndStartDateGreaterThanEqualOrderByStartDate(title, startDate);
+
+        assertThat(result).isNull();
+    }
+}

--- a/ticket/src/test/java/comento/backend/ticket/repository/PerformanceRepositroyTest.java
+++ b/ticket/src/test/java/comento/backend/ticket/repository/PerformanceRepositroyTest.java
@@ -1,5 +1,6 @@
 package comento.backend.ticket.repository;
 
+import comento.backend.ticket.config.customException.NotFoundDataException;
 import comento.backend.ticket.domain.Performance;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,43 +25,59 @@ public class PerformanceRepositroyTest {
         this.performanceRepository = performanceRepository;
     }
 
+    //Junit5 부터 접근제어자 생략 가능 (JUnit4 까지는 public이어야 했음!)
+
     @Test
     @DisplayName("[성공] 날짜를 정확하게 입력한 경우")
-    public void 공연_날짜_정보_조회() throws ParseException {
+    void 공연_날짜_정보_조회() throws ParseException {
         DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         Date startDate = format.parse("2020-06-20");
 
         List<Performance> result = performanceRepository.findByStartDateGreaterThanEqualOrderByStartDateAsc(startDate);
 
-        assertThat(result.size()).isNotNull();
+        assertThat(result.size()).isNotZero();
     }
 
     @Test
     @DisplayName("[성공] 날짜, 공연제목을 정확하게 입력한 경우")
-    public void 공연_날짜이름_정보_조회() throws ParseException {
+    void 공연_날짜이름_정보_조회() throws ParseException {
         DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         Date startDate = format.parse("2020-06-20");
         String title = "국립무용단 <산조>";
 
         List<Performance> result = performanceRepository.findByTitleAndStartDateGreaterThanEqualOrderByStartDate(title, startDate);
 
-        assertThat(result.size()).isNotNull();
+        assertThat(result.size()).isNotZero();
     }
 
     @Test
     @DisplayName("[실패] NOT FOUND ERROR")
-    public void 공연_날짜_정보_조회실패() throws ParseException {
+    void 공연_날짜_정보_조회실패() throws ParseException, NotFoundDataException {
         DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         Date startDate = format.parse("2021-06-31");
 
         List<Performance> result = performanceRepository.findByStartDateGreaterThanEqualOrderByStartDateAsc(startDate);
 
         assertThat(result).isNull();
+
+        /*앙댐
+        //given
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("2021-06-31");
+
+        //when
+        final NotFoundDataException exception = assertThrows(NotFoundDataException.class, () -> {
+            performanceRepository.findByStartDateGreaterThanEqualOrderByStartDateAsc(startDate);
+        });
+
+        //then
+        assertThat(exception.getMessage()).isNotNull();
+        */
     }
 
     @Test
     @DisplayName("[실패] BAD REQUEST")
-    public void 공연_날짜이름_정보_조회실패() throws ParseException {
+    void 공연_날짜이름_정보_조회실패() throws ParseException {
         DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         Date startDate = format.parse("ㄴ");
         String title = "국립무용단 <산조>";

--- a/ticket/src/test/java/comento/backend/ticket/service/PerformanceServiceTest.java
+++ b/ticket/src/test/java/comento/backend/ticket/service/PerformanceServiceTest.java
@@ -2,6 +2,7 @@ package comento.backend.ticket.service;
 
 import comento.backend.ticket.domain.Performance;
 import comento.backend.ticket.dto.PerformanceDto;
+import comento.backend.ticket.dto.PerformanceResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,7 +17,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
+@SpringBootTest //통합테스트
 @Transactional
 public class PerformanceServiceTest {
     private final PerformanceService performanceService;
@@ -28,54 +29,54 @@ public class PerformanceServiceTest {
 
     @Test
     @DisplayName("[성공] 날짜를 정확하게 입력한 경우")
-    public void 공연_날짜_정보_조회() throws ParseException {
+    void 공연_날짜_정보_조회() throws ParseException {
         DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
-        Date startDate = format.parse("2020-06-20");
+        Date startDate = format.parse("2021-06-20");
 
         PerformanceDto dto = new PerformanceDto(null, startDate);
 
-        List<Performance> result = performanceService.getListByDate(dto);
+        List<PerformanceResponse> result = performanceService.getListPerformance(dto);
 
-        assertThat(result.size()).isNotNull();
+        assertThat(result.size()).isNotZero();
     }
 
     @Test
     @DisplayName("[성공] 날짜, 공연제목을 정확하게 입력한 경우")
-    public void 공연_날짜이름_정보_조회() throws ParseException {
+    void 공연_날짜이름_정보_조회() throws ParseException {
         DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
-        Date startDate = format.parse("2020-06-20");
+        Date startDate = format.parse("2021-06-20");
         String title = "국립무용단 <산조>";
 
         PerformanceDto dto = new PerformanceDto(title, startDate);
 
-        List<Performance> result = performanceService.getListByDateAndTitle(dto);
+        List<PerformanceResponse> result = performanceService.getListPerformance(dto);
 
-        assertThat(result.size()).isNotNull();
+        assertThat(result.size()).isNotZero();
     }
 
     @Test
     @DisplayName("[실패] NOT FOUND ERROR")
-    public void 공연_날짜_정보_조회실패() throws ParseException {
+    void 공연_날짜_정보_조회실패() throws ParseException {
         DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         Date startDate = format.parse("2021-06-31");
         String title = "국립무용단 <산조>";
 
         PerformanceDto dto = new PerformanceDto(title, startDate);
 
-        List<Performance> result = performanceService.getListByDateAndTitle(dto);
+        List<PerformanceResponse> result = performanceService.getListPerformance(dto);
         assertThat(result).isNull();
     }
 
     @Test
     @DisplayName("[실패] BAD REQUEST")
-    public void 공연_날짜이름_정보_조회실패() throws ParseException {
+    void 공연_날짜이름_정보_조회실패() throws ParseException {
         DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         Date startDate = format.parse("S");
         String title = "국립무용단 <산조>";
 
         PerformanceDto dto = new PerformanceDto(title, startDate);
 
-        List<Performance> result = performanceService.getListByDateAndTitle(dto);
+        List<PerformanceResponse> result = performanceService.getListPerformance(dto);
         assertThat(result).isNull();
     }
 }

--- a/ticket/src/test/java/comento/backend/ticket/service/PerformanceServiceTest.java
+++ b/ticket/src/test/java/comento/backend/ticket/service/PerformanceServiceTest.java
@@ -1,0 +1,81 @@
+package comento.backend.ticket.service;
+
+import comento.backend.ticket.domain.Performance;
+import comento.backend.ticket.dto.PerformanceDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class PerformanceServiceTest {
+    private final PerformanceService performanceService;
+
+    @Autowired
+    public PerformanceServiceTest(PerformanceService performanceService) {
+        this.performanceService = performanceService;
+    }
+
+    @Test
+    @DisplayName("[성공] 날짜를 정확하게 입력한 경우")
+    public void 공연_날짜_정보_조회() throws ParseException {
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("2020-06-20");
+
+        PerformanceDto dto = new PerformanceDto(null, startDate);
+
+        List<Performance> result = performanceService.getListByDate(dto);
+
+        assertThat(result.size()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("[성공] 날짜, 공연제목을 정확하게 입력한 경우")
+    public void 공연_날짜이름_정보_조회() throws ParseException {
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("2020-06-20");
+        String title = "국립무용단 <산조>";
+
+        PerformanceDto dto = new PerformanceDto(title, startDate);
+
+        List<Performance> result = performanceService.getListByDateAndTitle(dto);
+
+        assertThat(result.size()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("[실패] NOT FOUND ERROR")
+    public void 공연_날짜_정보_조회실패() throws ParseException {
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("2021-06-31");
+        String title = "국립무용단 <산조>";
+
+        PerformanceDto dto = new PerformanceDto(title, startDate);
+
+        List<Performance> result = performanceService.getListByDateAndTitle(dto);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("[실패] BAD REQUEST")
+    public void 공연_날짜이름_정보_조회실패() throws ParseException {
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("S");
+        String title = "국립무용단 <산조>";
+
+        PerformanceDto dto = new PerformanceDto(title, startDate);
+
+        List<Performance> result = performanceService.getListByDateAndTitle(dto);
+        assertThat(result).isNull();
+    }
+}

--- a/ticket/src/test/java/comento/backend/ticket/service/PerformanceServiceTest2.java
+++ b/ticket/src/test/java/comento/backend/ticket/service/PerformanceServiceTest2.java
@@ -1,0 +1,92 @@
+package comento.backend.ticket.service;
+
+import comento.backend.ticket.config.customException.NotFoundDataException;
+import comento.backend.ticket.domain.Performance;
+import comento.backend.ticket.dto.PerformanceDto;
+import comento.backend.ticket.dto.PerformanceResponse;
+import comento.backend.ticket.repository.PerformanceRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times; //몇 번 호출되었는지 검증
+import static org.mockito.Mockito.verify; //해당 기능이 사용되었는지 검증
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class) //JUnit5와 Mockito 연동
+public class PerformanceServiceTest2 {
+
+    @Mock //mock객체로 생성
+    private PerformanceRepository performanceRepository;
+
+    private PerformanceService performanceService;
+
+    @BeforeEach
+    void init() {
+        //실제 존재하는 performanceRepository가 주입되는것이 아닌 Mock PerformanceRepository가 주입
+        performanceService = new PerformanceService(performanceRepository);
+    }
+    @Test
+    @DisplayName("[실패] 없는 날짜 정보 입력 - 404 NOT FOUND ERROR")
+    void 공연정보가_없으면_예외를_던진다2() throws ParseException {
+        //given
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("2021-06-31");
+
+        //performanceRepository를 mock했으니 테스트 상황에서 원하는 결과를 새롭게 구현하는 코드.
+        //테스트가 돌아가는 동안에는 willReturn에서 반환하는 결과를 반드시 return하므로 PerformanceRepository를 의존하지 않고도 돌아가는 테스트코드가 완성
+        given(performanceRepository.findByStartDateGreaterThanEqualOrderByStartDateAsc(startDate))
+                .willReturn(new ArrayList<Performance>());
+        //when
+        //공연정보가 없는 경우 Service에서는 NOT FOUND ERROR 예외 호출
+        NotFoundDataException nfde = assertThrows(NotFoundDataException.class, () -> {
+            performanceService.getListPerformance(new PerformanceDto(null, startDate));
+        });
+        //then
+        String msg = nfde.getMessage();
+        assertThat(msg).isEqualTo(null);
+    }
+    //@TODO : 성공해야 하는데 두 테스트 메소드 모두 NotFoundDataException 발생,,
+    @Test
+    @DisplayName("[성공] 날짜를 정확히 입력한 경우")
+    void 공연정보가_있으면_응답한다1() throws ParseException {
+        //given
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("2021-06-20");
+
+        given(performanceRepository.findByStartDateGreaterThanEqualOrderByStartDateAsc(startDate))
+                .willReturn(new ArrayList<>());
+        //when
+        List<PerformanceResponse> result =  performanceService.getListPerformance(new PerformanceDto(null, startDate));
+
+        //then
+        assertThat(result.size()).isNotZero(); //2개
+    }
+    @Test
+    @DisplayName("[성공] 날짜, 제목을 정확히 입력한 경우")
+    void 공연정보가_있으면_응답한다2() throws ParseException {
+        //given
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("2021-06-20");
+        String title = "국립무용단 <산조>";
+        List<Performance> temp = new ArrayList<>();
+        given(performanceRepository.findByTitleAndStartDateGreaterThanEqualOrderByStartDate(title, startDate))
+                .willReturn(temp);
+        //when
+        List<PerformanceResponse> result = performanceService.getListPerformance(new PerformanceDto(title, startDate));
+
+        //then
+        assertThat(result.size()).isNotZero();
+    }
+}


### PR DESCRIPTION
0. 목데이터는 #13 번 이슈에 csv 파일을 올렸습니다. (공공데이터를 이용함)
1. 날짜로 공연 정보를 조회하는 코드
2. 날짜&이름으로 공연 정보를 조회하는 코드
#### 200 OK
![1](https://user-images.githubusercontent.com/68772751/134761711-9417fbf0-f93e-4fa9-8f0a-32e46034448a.JPG)
![2](https://user-images.githubusercontent.com/68772751/134761712-782a8721-2a32-4217-b756-2edb77e465fc.JPG)
#### 400 Error
![3](https://user-images.githubusercontent.com/68772751/134761705-7ce13ebe-3949-487c-879a-c16251269abb.JPG)
#### 404 Error
![4](https://user-images.githubusercontent.com/68772751/134761710-c53db307-41be-49d9-837a-a1a3368e092d.JPG)
----
`GlobalExceptionHandler.java`
- mapping 실패 시 발생하는 에러 클래스 추가

`PerformanceRepository.java`
- 12번줄 주석 잘못하고 안지웠습니다!
- 다음 피드백 후 반영 시 지우겠습니다.
