### PR TITLE
[feat#11] 공연 좌석 정보 조회, 공연 좌석 예약 (동시성 해결 X)

### DIFF
--- a/ticket/build.gradle
+++ b/ticket/build.gradle
@@ -22,6 +22,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	// validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'mysql:mysql-connector-java'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/ticket/src/main/java/comento/backend/ticket/config/ErrorCode.java
+++ b/ticket/src/main/java/comento/backend/ticket/config/ErrorCode.java
@@ -1,0 +1,25 @@
+package comento.backend.ticket.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    /**
+     * @see : 예외케이스 정의
+     */
+
+    INVALID_VALUE(400, HttpStatus.BAD_REQUEST, "BAD REQUEST", "잘못된 요청입니다. 다시 요청해주세요."),
+    NO_USER(401, HttpStatus.UNAUTHORIZED,"UNAUTHORIZED",  "등록되지 않은 사용자입니다"),
+    NO_DATA(404, HttpStatus.NOT_FOUND, "NOT FOUND ERROR", "요청할 수 없는 리소스입니다."),
+    INVALID_USER(409, HttpStatus.CONFLICT, "CONFLICT", "이미 존재하는 사용자입니다."),
+    INVALID_SEAT(409, HttpStatus.CONFLICT, "CONFLICT", "이미 예약된 좌석입니다."),
+    SERVER_ERROR(500, HttpStatus.INTERNAL_SERVER_ERROR, "INTERVAL_SERVER ERROR", "서버 에러입니다.");
+
+    private final Integer status;
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String reason;
+}

--- a/ticket/src/main/java/comento/backend/ticket/config/ErrorResponse.java
+++ b/ticket/src/main/java/comento/backend/ticket/config/ErrorResponse.java
@@ -1,0 +1,24 @@
+package comento.backend.ticket.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class ErrorResponse<T>{
+    private Integer status;
+    private String message;
+    private String reason;
+
+    //공통된 Error Message를 전송할 때 사용
+    public static ErrorResponse res(final Integer status, final String message, final String reason){
+        return ErrorResponse.builder()
+                .status(status)
+                .message(message)
+                .reason(reason)
+                .build();
+    }
+}
+

--- a/ticket/src/main/java/comento/backend/ticket/config/GlobalExceptionHandler.java
+++ b/ticket/src/main/java/comento/backend/ticket/config/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -26,10 +27,14 @@ public class GlobalExceptionHandler {
      */
 
     //ConstraintViolationException.class 는 유효성 검사 실패시 (@Validated)
-    @ExceptionHandler({JsonParseException.class, MethodArgumentNotValidException.class, ConstraintViolationException.class, MethodArgumentTypeMismatchException.class})
+    @ExceptionHandler({JsonParseException.class,
+            MethodArgumentNotValidException.class,
+                    ConstraintViolationException.class,
+            MethodArgumentTypeMismatchException.class,
+            MissingServletRequestParameterException.class})
     public static ResponseEntity missMatchExceptionHandler(Throwable t){
         errorCode = ErrorCode.INVALID_VALUE;
-        log.error(errorCode.getStatus() + errorCode.getMessage(), t);
+        log.error(errorCode.getStatus() + " " + errorCode.getMessage(), t);
         return new ResponseEntity<>(ErrorResponse.res(errorCode.getStatus(), errorCode.getMessage(), errorCode.getReason()),
                 errorCode.getHttpStatus());
     }
@@ -45,7 +50,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({NoSuchElementException.class, NotFoundException.class, NotFoundDataException.class})
     public static ResponseEntity notFoundExceptionHandler(Throwable t){
         errorCode = ErrorCode.NO_DATA;
-        log.error(errorCode.getStatus()+ " " + errorCode.getMessage(), t);
+        log.error(errorCode.getStatus() + " " + errorCode.getMessage(), t);
         return new ResponseEntity<>(ErrorResponse.res(errorCode.getStatus(), errorCode.getMessage(), errorCode.getReason()),
                 errorCode.getHttpStatus());
     }
@@ -54,10 +59,10 @@ public class GlobalExceptionHandler {
     public static ResponseEntity duplicateExceptionHandler(DuplicatedException e){
         if (e.getMessage() == "UserService") { //호출된 곳이 UserService
             errorCode = ErrorCode.INVALID_USER;
-            log.error(errorCode.getStatus()+ " " + errorCode.getMessage(), e);
+            log.error(errorCode.getStatus() + " " + errorCode.getMessage(), e);
         }else{ //좌석 예약 시
             errorCode = ErrorCode.INVALID_SEAT;
-            log.error(errorCode.getStatus()+ " " + errorCode.getMessage(), e);
+            log.error(errorCode.getStatus() + " " + errorCode.getMessage(), e);
         }
         return new ResponseEntity<>(ErrorResponse.res(errorCode.getStatus(), errorCode.getMessage(), errorCode.getReason()),
                 errorCode.getHttpStatus());
@@ -66,7 +71,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({IllegalStateException.class, RuntimeException.class})
     public static ResponseEntity IllExceptionHandler(Throwable t){
         errorCode = ErrorCode.SERVER_ERROR;
-        log.error(errorCode.getStatus()+ " " + errorCode.getMessage(), t);
+        log.error(errorCode.getStatus() + " " + errorCode.getMessage(), t);
         return new ResponseEntity<>(ErrorResponse.res(errorCode.getStatus(), errorCode.getMessage(), errorCode.getReason()),
                 errorCode.getHttpStatus());
     }

--- a/ticket/src/main/java/comento/backend/ticket/config/GlobalExceptionHandler.java
+++ b/ticket/src/main/java/comento/backend/ticket/config/GlobalExceptionHandler.java
@@ -1,0 +1,73 @@
+package comento.backend.ticket.config;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import comento.backend.ticket.config.customException.DuplicatedException;
+import comento.backend.ticket.config.customException.NoAuthException;
+import comento.backend.ticket.config.customException.NotFoundDataException;
+import javassist.NotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import javax.validation.ConstraintViolationException;
+import java.util.NoSuchElementException;
+
+@RestControllerAdvice //@Conroller 전역에서 발생 가능한 예외를 잡아 처리
+@Slf4j
+public class GlobalExceptionHandler {
+    private static ErrorCode errorCode;
+
+    /**
+     * 특정 Exception을 지정하여 별도로 처리
+     */
+
+    //ConstraintViolationException.class 는 유효성 검사 실패시 (@Validated)
+    @ExceptionHandler({JsonParseException.class, MethodArgumentNotValidException.class, ConstraintViolationException.class, MethodArgumentTypeMismatchException.class})
+    public static ResponseEntity missMatchExceptionHandler(Throwable t){
+        errorCode = ErrorCode.INVALID_VALUE;
+        log.error(errorCode.getStatus() + errorCode.getMessage(), t);
+        return new ResponseEntity<>(ErrorResponse.res(errorCode.getStatus(), errorCode.getMessage(), errorCode.getReason()),
+                errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(NoAuthException.class)
+    public static ResponseEntity noAuthExceptionHandler(NoAuthException e){
+        errorCode = ErrorCode.NO_USER;
+        log.error(errorCode.getStatus() + errorCode.getMessage(), e);
+        return new ResponseEntity<>(ErrorResponse.res(errorCode.getStatus(), errorCode.getMessage(), errorCode.getReason()),
+                errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler({NoSuchElementException.class, NotFoundException.class, NotFoundDataException.class})
+    public static ResponseEntity notFoundExceptionHandler(Throwable t){
+        errorCode = ErrorCode.NO_DATA;
+        log.error(errorCode.getStatus()+ " " + errorCode.getMessage(), t);
+        return new ResponseEntity<>(ErrorResponse.res(errorCode.getStatus(), errorCode.getMessage(), errorCode.getReason()),
+                errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(DuplicatedException.class)
+    public static ResponseEntity duplicateExceptionHandler(DuplicatedException e){
+        if (e.getMessage() == "UserService") { //호출된 곳이 UserService
+            errorCode = ErrorCode.INVALID_USER;
+            log.error(errorCode.getStatus()+ " " + errorCode.getMessage(), e);
+        }else{ //좌석 예약 시
+            errorCode = ErrorCode.INVALID_SEAT;
+            log.error(errorCode.getStatus()+ " " + errorCode.getMessage(), e);
+        }
+        return new ResponseEntity<>(ErrorResponse.res(errorCode.getStatus(), errorCode.getMessage(), errorCode.getReason()),
+                errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler({IllegalStateException.class, RuntimeException.class})
+    public static ResponseEntity IllExceptionHandler(Throwable t){
+        errorCode = ErrorCode.SERVER_ERROR;
+        log.error(errorCode.getStatus()+ " " + errorCode.getMessage(), t);
+        return new ResponseEntity<>(ErrorResponse.res(errorCode.getStatus(), errorCode.getMessage(), errorCode.getReason()),
+                errorCode.getHttpStatus());
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/config/SuccessCode.java
+++ b/ticket/src/main/java/comento/backend/ticket/config/SuccessCode.java
@@ -1,0 +1,17 @@
+package comento.backend.ticket.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessCode {
+
+    OK(200, HttpStatus.OK, "OK"),
+    CREATED(201, HttpStatus.CREATED, "CREATED");
+
+    private final Integer status;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/ticket/src/main/java/comento/backend/ticket/config/SuccessResponse.java
+++ b/ticket/src/main/java/comento/backend/ticket/config/SuccessResponse.java
@@ -1,0 +1,24 @@
+package comento.backend.ticket.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class SuccessResponse<T> {
+    private Integer status;
+    private String message;
+    private Object data;
+
+    //공통된 Success Message를 전송할 때 사용
+    public static SuccessResponse res(final Integer status, final String message, final Object data){
+        return SuccessResponse.builder()
+                .status(status)
+                .message(message)
+                .data(data)
+                .build();
+    }
+
+}

--- a/ticket/src/main/java/comento/backend/ticket/config/customException/DuplicatedException.java
+++ b/ticket/src/main/java/comento/backend/ticket/config/customException/DuplicatedException.java
@@ -1,0 +1,10 @@
+package comento.backend.ticket.config.customException;
+
+public class DuplicatedException extends RuntimeException{
+    public DuplicatedException() {
+    }
+
+    public DuplicatedException(String message) {
+        super(message);
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/config/customException/NoAuthException.java
+++ b/ticket/src/main/java/comento/backend/ticket/config/customException/NoAuthException.java
@@ -1,0 +1,10 @@
+package comento.backend.ticket.config.customException;
+
+public class NoAuthException extends RuntimeException{
+    public NoAuthException() {
+    }
+
+    public NoAuthException(String message) {
+        super(message);
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/config/customException/NotFoundDataException.java
+++ b/ticket/src/main/java/comento/backend/ticket/config/customException/NotFoundDataException.java
@@ -1,0 +1,10 @@
+package comento.backend.ticket.config.customException;
+
+public class NotFoundDataException extends RuntimeException{
+    public NotFoundDataException() {
+    }
+
+    public NotFoundDataException(String message) {
+        super(message);
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/controller/BookingController.java
+++ b/ticket/src/main/java/comento/backend/ticket/controller/BookingController.java
@@ -4,52 +4,42 @@ import comento.backend.ticket.config.SuccessCode;
 import comento.backend.ticket.config.SuccessResponse;
 import comento.backend.ticket.domain.Booking;
 import comento.backend.ticket.dto.BookingDto;
+import comento.backend.ticket.dto.BookingResponse;
 import comento.backend.ticket.dto.BookingResponseCreated;
-import comento.backend.ticket.dto.SeatDto;
-import comento.backend.ticket.service.BookingHistoryService;
 import comento.backend.ticket.service.BookingService;
-import comento.backend.ticket.service.SeatService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.*;
 
 @RestController
 @RequestMapping("/api/performance/booking")
 public class BookingController {
     private final BookingService bookingService;
-    private final SeatService seatService;
-    private final BookingHistoryService bookingHistoryService;
     private SuccessCode successCode;
 
     @Autowired
-    public BookingController(BookingService bookingService, SeatService seatService, BookingHistoryService bookingHistoryService) {
+    public BookingController(BookingService bookingService) {
         this.bookingService = bookingService;
-        this.seatService = seatService;
-        this.bookingHistoryService = bookingHistoryService;
     }
 
     @PostMapping("")
     public ResponseEntity addBooking(@Valid @RequestBody BookingDto reqBooking){
-        Booking booking = bookingService.saveBookging(reqBooking);
-        if(booking == null){
-
-        }
-
+        bookingService.saveBookging(reqBooking);
         BookingResponseCreated result = new BookingResponseCreated(reqBooking.getSeatType(), reqBooking.getSeatNumber());
         successCode = SuccessCode.CREATED;
         return new ResponseEntity(SuccessResponse.res(successCode.getStatus(), successCode.getMessage(), result),
                 HttpStatus.CREATED);
     }
 
-    //@TODO : 예약 정보 조회하기
-//    @GetMapping("/email/{email}")
-//    public ResponseEntity showMyBooking(@Valid @PathVariable String email){
-//
-//        successCode = SuccessCode.OK;
-//        return new ResponseEntity(SuccessResponse.res(successCode.getStatus(), successCode.getMessage(), result)
-//                HttpStatus.OK);
-//    }
+    @GetMapping("/email/{email}")
+    public ResponseEntity showMyBooking(@Valid @PathVariable String email){
+        List<BookingResponse> result = bookingService.getMyBooking(email);
+        successCode = SuccessCode.OK;
+        return new ResponseEntity(SuccessResponse.res(successCode.getStatus(), successCode.getMessage(), result),
+                HttpStatus.OK);
+    }
 }

--- a/ticket/src/main/java/comento/backend/ticket/controller/BookingController.java
+++ b/ticket/src/main/java/comento/backend/ticket/controller/BookingController.java
@@ -1,0 +1,55 @@
+package comento.backend.ticket.controller;
+
+import comento.backend.ticket.config.SuccessCode;
+import comento.backend.ticket.config.SuccessResponse;
+import comento.backend.ticket.domain.Booking;
+import comento.backend.ticket.dto.BookingDto;
+import comento.backend.ticket.dto.BookingResponseCreated;
+import comento.backend.ticket.dto.SeatDto;
+import comento.backend.ticket.service.BookingHistoryService;
+import comento.backend.ticket.service.BookingService;
+import comento.backend.ticket.service.SeatService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/performance/booking")
+public class BookingController {
+    private final BookingService bookingService;
+    private final SeatService seatService;
+    private final BookingHistoryService bookingHistoryService;
+    private SuccessCode successCode;
+
+    @Autowired
+    public BookingController(BookingService bookingService, SeatService seatService, BookingHistoryService bookingHistoryService) {
+        this.bookingService = bookingService;
+        this.seatService = seatService;
+        this.bookingHistoryService = bookingHistoryService;
+    }
+
+    @PostMapping("")
+    public ResponseEntity addBooking(@Valid @RequestBody BookingDto reqBooking){
+        Booking booking = bookingService.saveBookging(reqBooking);
+        if(booking == null){
+
+        }
+
+        BookingResponseCreated result = new BookingResponseCreated(reqBooking.getSeatType(), reqBooking.getSeatNumber());
+        successCode = SuccessCode.CREATED;
+        return new ResponseEntity(SuccessResponse.res(successCode.getStatus(), successCode.getMessage(), result),
+                HttpStatus.CREATED);
+    }
+
+    //@TODO : 예약 정보 조회하기
+//    @GetMapping("/email/{email}")
+//    public ResponseEntity showMyBooking(@Valid @PathVariable String email){
+//
+//        successCode = SuccessCode.OK;
+//        return new ResponseEntity(SuccessResponse.res(successCode.getStatus(), successCode.getMessage(), result)
+//                HttpStatus.OK);
+//    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/controller/PerformanceController.java
+++ b/ticket/src/main/java/comento/backend/ticket/controller/PerformanceController.java
@@ -1,0 +1,48 @@
+package comento.backend.ticket.controller;
+
+import comento.backend.ticket.config.SuccessCode;
+import comento.backend.ticket.config.SuccessResponse;
+import comento.backend.ticket.domain.Performance;
+import comento.backend.ticket.dto.PerformanceDto;
+import comento.backend.ticket.dto.PerformanceResponse;
+import comento.backend.ticket.service.PerformanceService;
+import comento.backend.ticket.service.SeatService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.util.*;
+import java.util.Date;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@RestController
+@RequestMapping("/api/performance")
+public class PerformanceController {
+    private final PerformanceService performanceService;
+    private final SeatService seatService;
+    private SuccessCode successCode = SuccessCode.OK;
+
+    @Autowired
+    public PerformanceController(PerformanceService performanceService, SeatService seatService) {
+        this.performanceService = performanceService;
+        this.seatService = seatService;
+    }
+
+    @GetMapping("/info")
+    public ResponseEntity showPerformanceInfo(@Valid @RequestParam(value = "date", required = true)
+                                                  @DateTimeFormat(pattern = "yyyy-MM-dd") Date date,
+                                              @Valid @RequestParam(value = "title", required = false) String title) {
+        PerformanceDto performanceDto = new PerformanceDto(title, date);
+        List<PerformanceResponse> result = performanceService.getListPerformance(performanceDto);
+
+        return new ResponseEntity(SuccessResponse.res(successCode.getStatus(), successCode.getMessage(), result),
+                HttpStatus.OK);
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/controller/PerformanceController.java
+++ b/ticket/src/main/java/comento/backend/ticket/controller/PerformanceController.java
@@ -5,8 +5,10 @@ import comento.backend.ticket.config.SuccessResponse;
 import comento.backend.ticket.domain.Performance;
 import comento.backend.ticket.dto.PerformanceDto;
 import comento.backend.ticket.dto.PerformanceResponse;
+import comento.backend.ticket.dto.SeatResponse;
 import comento.backend.ticket.service.PerformanceService;
 import comento.backend.ticket.service.SeatService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
@@ -19,8 +21,6 @@ import org.springframework.web.bind.annotation.RestController;
 import javax.validation.Valid;
 import java.util.*;
 import java.util.Date;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @RestController
 @RequestMapping("/api/performance")
@@ -43,6 +43,19 @@ public class PerformanceController {
         List<PerformanceResponse> result = performanceService.getListPerformance(performanceDto);
 
         return new ResponseEntity(SuccessResponse.res(successCode.getStatus(), successCode.getMessage(), result),
+                HttpStatus.OK);
+    }
+
+    @GetMapping("/info/seat")
+    public ResponseEntity showPerformanceSeatInfo(@Valid @RequestParam(value = "date", required = true)
+                                              @DateTimeFormat(pattern = "yyyy-MM-dd") Date date,
+                                              @Valid @RequestParam(value = "title", required = true) String title) {
+        PerformanceDto performanceDto = new PerformanceDto(title, date);
+        List<PerformanceResponse> performanceData = performanceService.getListPerformance(performanceDto);
+
+        List<SeatResponse> seatResult = seatService.getListPerformanceSeat(performanceData.get(0));
+
+        return new ResponseEntity(SuccessResponse.res(successCode.getStatus(), successCode.getMessage(), seatResult),
                 HttpStatus.OK);
     }
 }

--- a/ticket/src/main/java/comento/backend/ticket/controller/UserController.java
+++ b/ticket/src/main/java/comento/backend/ticket/controller/UserController.java
@@ -1,0 +1,32 @@
+package comento.backend.ticket.controller;
+
+import comento.backend.ticket.config.SuccessCode;
+import comento.backend.ticket.config.SuccessResponse;
+import comento.backend.ticket.config.customException.NotFoundDataException;
+import comento.backend.ticket.domain.User;
+import comento.backend.ticket.dto.UserDto;
+import comento.backend.ticket.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+public class UserController {
+    private SuccessCode successCode = SuccessCode.CREATED;
+    private final UserService userService;
+    private static final String CREATED_MSG = "등록 성공";
+
+    @Autowired
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity addEmail(@Validated @RequestBody UserDto userDto){
+        userService.saveUser(userDto);
+        return new ResponseEntity<>(SuccessResponse.res(successCode.getStatus(), successCode.getMessage(), CREATED_MSG),
+                successCode.getHttpStatus());
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/domain/Booking.java
+++ b/ticket/src/main/java/comento/backend/ticket/domain/Booking.java
@@ -1,0 +1,48 @@
+package comento.backend.ticket.domain;
+
+import lombok.Builder;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+
+import javax.persistence.*;
+import java.util.Date;
+
+@Entity
+@Data
+@Table(name="Booking")
+public class Booking {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="booking_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "performance_id")
+    private Performance performance;
+
+    @ManyToOne
+    @JoinColumn(name = "seat_id")
+    private Seat seat;
+
+    @Column(name="create_at")
+    @CreationTimestamp //Entity가 생성되어 저장될 때 시간이 자동 저장
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date createAt;
+
+    public Booking(){}
+
+    @Builder
+    public Booking(Long id, User user, Performance performance, Seat seat, Date createAt) {
+        this.id = id;
+        this.user = user;
+        this.performance = performance;
+        this.seat = seat;
+        this.createAt = createAt;
+    }
+}
+

--- a/ticket/src/main/java/comento/backend/ticket/domain/Booking.java
+++ b/ticket/src/main/java/comento/backend/ticket/domain/Booking.java
@@ -17,15 +17,15 @@ public class Booking {
     @Column(name="booking_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "performance_id")
     private Performance performance;
 
-    @ManyToOne
+    @OneToOne
     @JoinColumn(name = "seat_id")
     private Seat seat;
 

--- a/ticket/src/main/java/comento/backend/ticket/domain/BookingHistory.java
+++ b/ticket/src/main/java/comento/backend/ticket/domain/BookingHistory.java
@@ -2,8 +2,6 @@ package comento.backend.ticket.domain;
 
 import lombok.Builder;
 import lombok.Data;
-import lombok.Getter;
-import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 
 import javax.persistence.*;
@@ -26,11 +24,11 @@ public class BookingHistory {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "performance_id")
     private Performance performance;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "seat_id")
     private Seat seat;
 

--- a/ticket/src/main/java/comento/backend/ticket/domain/BookingHistory.java
+++ b/ticket/src/main/java/comento/backend/ticket/domain/BookingHistory.java
@@ -1,0 +1,51 @@
+package comento.backend.ticket.domain;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import javax.persistence.*;
+import java.util.Date;
+
+@Entity
+@Data
+@Table(name="BookingHistory")
+public class BookingHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="bh_id") //booking_histroy id
+    private Long id;
+
+    @Column(name = "is_success", columnDefinition = "boolean default false")
+    private Boolean isSuccess;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "performance_id")
+    private Performance performance;
+
+    @ManyToOne
+    @JoinColumn(name = "seat_id")
+    private Seat seat;
+
+    @Column(name="create_at")
+    @CreationTimestamp //Entity가 생성되어 저장될 때 시간이 자동 저장
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date createAt;
+
+    public BookingHistory(){}
+
+    @Builder
+    public BookingHistory(Boolean isSuccess, User user, Performance performance, Seat seat) {
+        this.isSuccess = isSuccess;
+        this.user = user;
+        this.performance = performance;
+        this.seat = seat;
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/domain/Performance.java
+++ b/ticket/src/main/java/comento/backend/ticket/domain/Performance.java
@@ -1,0 +1,55 @@
+package comento.backend.ticket.domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+import javax.persistence.*;
+import java.util.Date;
+
+@Entity
+@Data
+@Table(name="Performance")
+public class Performance {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="performance_id")
+    private Long id;
+
+    @Column
+    private String title;
+
+    @Column
+    private String genere;
+
+    @Column(name="start_date")
+    @Temporal(TemporalType.DATE)
+    private Date startDate;
+
+    @Column(name="end_date")
+    @Temporal(TemporalType.DATE)
+    private Date endDate;
+
+    @Column(columnDefinition = "TEXT")
+    private String price;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "running_time")
+    private String runningTime;
+
+    public Performance(){}
+
+    @Builder
+    public Performance(Long id, String title, String genere, Date startDate, Date endDate, String price, String description, String runningTime) {
+        this.id = id;
+        this.title = title;
+        this.genere = genere;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.price = price;
+        this.description = description;
+        this.runningTime = runningTime;
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/domain/Seat.java
+++ b/ticket/src/main/java/comento/backend/ticket/domain/Seat.java
@@ -16,7 +16,7 @@ public class Seat {
     @Column(name = "seat_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "performance_id")
     private Performance performance;
 

--- a/ticket/src/main/java/comento/backend/ticket/domain/Seat.java
+++ b/ticket/src/main/java/comento/backend/ticket/domain/Seat.java
@@ -1,0 +1,43 @@
+package comento.backend.ticket.domain;
+
+import comento.backend.ticket.dto.SeatType;
+import lombok.Builder;
+import lombok.Data;
+
+import javax.persistence.*;
+
+@Entity
+@Data
+@Table(name = "Seat")
+public class Seat {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "seat_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "performance_id")
+    private Performance performance;
+
+    @Column(name = "seat_type", nullable = true)
+    @Enumerated(EnumType.STRING) //enum 타입으로 DB에 저장
+    private SeatType seatType;
+
+    @Column(name = "seat_number", nullable = true)
+    private Integer seatNumber;
+
+    @Column(name = "is_booking", columnDefinition = "boolean default false")
+    private boolean isBooking;
+
+    public Seat(){}
+
+    @Builder
+    public Seat(Long id, Performance performance, SeatType seatType, Integer seatNumber, boolean isBooking) {
+        this.id = id;
+        this.performance = performance;
+        this.seatType = seatType;
+        this.seatNumber = seatNumber;
+        this.isBooking = isBooking;
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/domain/User.java
+++ b/ticket/src/main/java/comento/backend/ticket/domain/User.java
@@ -1,0 +1,37 @@
+package comento.backend.ticket.domain;
+
+import lombok.Builder;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.springframework.data.annotation.CreatedDate;
+
+import javax.persistence.*;
+import java.util.Date;
+
+@Entity
+@Data
+@Table(name="User")
+public class User{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="user_id")
+    private Long id;
+
+    @Column(nullable = true)
+    private String email;
+
+    @Column(name="create_at")
+    @CreationTimestamp //Entity가 생성되어 저장될 때 시간이 자동 저장
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date createAt;
+
+    public User(){}
+
+    @Builder
+    public User(long id, String email, Date create_at) {
+        this.id = id;
+        this.email = email;
+        this.createAt = createAt;
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/dto/BookingDto.java
+++ b/ticket/src/main/java/comento/backend/ticket/dto/BookingDto.java
@@ -27,37 +27,8 @@ public class BookingDto {
     private SeatType seatType;
     private Integer seatNumber;
     private String price;
-    private User user;
-    private Performance performance;
-    private Seat seat;
 
-    public BookingDto() {
-    }
-
-    public BookingDto(Long id, String title, Date startDate, String email, SeatType seatType, Integer seatNumber, String price) {
-        this.id = id;
-        this.title = title;
-        this.startDate = startDate;
-        this.email = email;
-        this.seatType = seatType;
-        this.seatNumber = seatNumber;
-        this.price = price;
-    }
-
-    public BookingDto(Long id, String title, Date startDate, String email, SeatType seatType, Integer seatNumber, String price, User user, Performance performance, Seat seat) {
-        this.id = id;
-        this.title = title;
-        this.startDate = startDate;
-        this.email = email;
-        this.seatType = seatType;
-        this.seatNumber = seatNumber;
-        this.price = price;
-        this.user = user;
-        this.performance = performance;
-        this.seat = seat;
-    }
-
-    public Booking toEntity() {
+    public Booking toEntity(final User user, final Performance performance, final Seat seat) {
         return Booking.builder()
                 .user(user)
                 .performance(performance)

--- a/ticket/src/main/java/comento/backend/ticket/dto/BookingDto.java
+++ b/ticket/src/main/java/comento/backend/ticket/dto/BookingDto.java
@@ -1,0 +1,68 @@
+package comento.backend.ticket.dto;
+
+import comento.backend.ticket.domain.Booking;
+import comento.backend.ticket.domain.Performance;
+import comento.backend.ticket.domain.Seat;
+import comento.backend.ticket.domain.User;
+import lombok.Data;
+import lombok.Getter;
+
+import java.util.Date;
+
+/*
+   "date" : 2021-09-04,
+   "title" : "뮤지컬",
+   "email" :"kimhyejung12@naver.com"
+   "seat" : "VIP석"
+   "seat_number" : 2
+ */
+
+@Getter
+@Data
+public class BookingDto {
+    private Long id;
+    private String title;
+    private Date startDate;
+    private String email;
+    private SeatType seatType;
+    private Integer seatNumber;
+    private String price;
+    private User user;
+    private Performance performance;
+    private Seat seat;
+
+    public BookingDto() {
+    }
+
+    public BookingDto(Long id, String title, Date startDate, String email, SeatType seatType, Integer seatNumber, String price) {
+        this.id = id;
+        this.title = title;
+        this.startDate = startDate;
+        this.email = email;
+        this.seatType = seatType;
+        this.seatNumber = seatNumber;
+        this.price = price;
+    }
+
+    public BookingDto(Long id, String title, Date startDate, String email, SeatType seatType, Integer seatNumber, String price, User user, Performance performance, Seat seat) {
+        this.id = id;
+        this.title = title;
+        this.startDate = startDate;
+        this.email = email;
+        this.seatType = seatType;
+        this.seatNumber = seatNumber;
+        this.price = price;
+        this.user = user;
+        this.performance = performance;
+        this.seat = seat;
+    }
+
+    public Booking toEntity() {
+        return Booking.builder()
+                .user(user)
+                .performance(performance)
+                .seat(seat)
+                .build();
+    }
+
+}

--- a/ticket/src/main/java/comento/backend/ticket/dto/BookingHistoryDto.java
+++ b/ticket/src/main/java/comento/backend/ticket/dto/BookingHistoryDto.java
@@ -4,14 +4,27 @@ import comento.backend.ticket.domain.BookingHistory;
 import comento.backend.ticket.domain.Performance;
 import comento.backend.ticket.domain.Seat;
 import comento.backend.ticket.domain.User;
+import lombok.Builder;
 import lombok.Data;
 
 @Data
 public class BookingHistoryDto {
+    private Long id;
     private boolean isSuccess;
     private User user;
     private Performance performance;
     private Seat seat;
+
+    public BookingHistoryDto(){}
+
+    @Builder
+    public BookingHistoryDto(Long id, boolean isSuccess, User user, Performance performance, Seat seat) {
+        this.id = id;
+        this.isSuccess = isSuccess;
+        this.user = user;
+        this.performance = performance;
+        this.seat = seat;
+    }
 
     public BookingHistory toEntity() {
         return BookingHistory.builder()

--- a/ticket/src/main/java/comento/backend/ticket/dto/BookingHistoryDto.java
+++ b/ticket/src/main/java/comento/backend/ticket/dto/BookingHistoryDto.java
@@ -1,0 +1,24 @@
+package comento.backend.ticket.dto;
+
+import comento.backend.ticket.domain.BookingHistory;
+import comento.backend.ticket.domain.Performance;
+import comento.backend.ticket.domain.Seat;
+import comento.backend.ticket.domain.User;
+import lombok.Data;
+
+@Data
+public class BookingHistoryDto {
+    private boolean isSuccess;
+    private User user;
+    private Performance performance;
+    private Seat seat;
+
+    public BookingHistory toEntity() {
+        return BookingHistory.builder()
+                .isSuccess(isSuccess)
+                .user(user)
+                .performance(performance)
+                .seat(seat)
+                .build();
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/dto/BookingResponse.java
+++ b/ticket/src/main/java/comento/backend/ticket/dto/BookingResponse.java
@@ -1,0 +1,26 @@
+package comento.backend.ticket.dto;
+
+import lombok.Data;
+
+import java.util.Date;
+
+@Data
+public class BookingResponse {
+    private String title;
+    private Date startDate;
+    private String email;
+    private SeatType seatType;
+    private Integer seatNumber;
+    private String price;
+
+    public BookingResponse(){}
+
+    public BookingResponse(String title, Date startDate, String email, SeatType seatType, Integer seatNumber, String price) {
+        this.title = title;
+        this.startDate = startDate;
+        this.email = email;
+        this.seatType = seatType;
+        this.seatNumber = seatNumber;
+        this.price = price;
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/dto/BookingResponseCreated.java
+++ b/ticket/src/main/java/comento/backend/ticket/dto/BookingResponseCreated.java
@@ -1,0 +1,14 @@
+package comento.backend.ticket.dto;
+
+import lombok.Data;
+
+@Data
+public class BookingResponseCreated {
+    private SeatType seatType;
+    private Integer seatNumber;
+
+    public BookingResponseCreated(SeatType seatType, Integer seatNumber) {
+        this.seatType = seatType;
+        this.seatNumber = seatNumber;
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/dto/PerformanceDto.java
+++ b/ticket/src/main/java/comento/backend/ticket/dto/PerformanceDto.java
@@ -1,0 +1,35 @@
+package comento.backend.ticket.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+
+@Getter
+@Setter
+public class PerformanceDto {
+    private String title;
+    private Date startDate;
+    private Date endDate;
+    private String price;
+    private String genere;
+    private String description;
+    private String runningTime;
+
+    public PerformanceDto(){}
+
+    public PerformanceDto(String title, Date startDate) {
+        this.title = title;
+        this.startDate = startDate;
+    }
+
+    public PerformanceDto(String title, Date startDate, Date endDate, String price, String genere, String description, String runningTime) {
+        this.title = title;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.price = price;
+        this.genere = genere;
+        this.description = description;
+        this.runningTime = runningTime;
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/dto/PerformanceResponse.java
+++ b/ticket/src/main/java/comento/backend/ticket/dto/PerformanceResponse.java
@@ -1,0 +1,43 @@
+package comento.backend.ticket.dto;
+
+import comento.backend.ticket.domain.Performance;
+import lombok.Data;
+
+import java.util.*;
+
+@Data
+public class PerformanceResponse {
+    private Long id;
+    private String title;
+    private Date startDate;
+    private Date endDate;
+    private String price;
+    private String genere;
+    private String description;
+    private String runningTime;
+
+    public PerformanceResponse(Long id, String title, Date startDate, Date endDate, String price, String genere, String description, String runningTime) {
+        this.id = id;
+        this.title = title;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.price = price;
+        this.genere = genere;
+        this.description = description;
+        this.runningTime = runningTime;
+    }
+
+    //convert
+    public static PerformanceResponse of(Performance performance){
+        return new PerformanceResponse(
+                performance.getId(),
+                performance.getTitle(),
+                performance.getStartDate(),
+                performance.getEndDate(),
+                performance.getPrice(),
+                performance.getGenere(),
+                performance.getDescription(),
+                performance.getRunningTime()
+        );
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/dto/SeatDto.java
+++ b/ticket/src/main/java/comento/backend/ticket/dto/SeatDto.java
@@ -2,6 +2,7 @@ package comento.backend.ticket.dto;
 
 import comento.backend.ticket.domain.Performance;
 import comento.backend.ticket.domain.Seat;
+import lombok.Builder;
 import lombok.Data;
 
 @Data
@@ -12,6 +13,9 @@ public class SeatDto {
     private Integer seatNumber;
     private boolean isBooking;
 
+    public SeatDto(){};
+
+    @Builder
     public SeatDto(Long seat_id, Performance performance, SeatType seatType, Integer seatNumber, boolean isBooking) {
         this.seat_id = seat_id;
         this.performance = performance;

--- a/ticket/src/main/java/comento/backend/ticket/dto/SeatDto.java
+++ b/ticket/src/main/java/comento/backend/ticket/dto/SeatDto.java
@@ -1,0 +1,32 @@
+package comento.backend.ticket.dto;
+
+import comento.backend.ticket.domain.Performance;
+import comento.backend.ticket.domain.Seat;
+import lombok.Data;
+
+@Data
+public class SeatDto {
+    private Long seat_id;
+    private Performance performance;
+    private SeatType seatType;
+    private Integer seatNumber;
+    private boolean isBooking;
+
+    public SeatDto(Long seat_id, Performance performance, SeatType seatType, Integer seatNumber, boolean isBooking) {
+        this.seat_id = seat_id;
+        this.performance = performance;
+        this.seatType = seatType;
+        this.seatNumber = seatNumber;
+        this.isBooking = isBooking;
+    }
+
+    public Seat toEntity(){
+        return Seat.builder()
+                .id(seat_id)
+                .performance(performance)
+                .seatType(seatType)
+                .seatNumber(seatNumber)
+                .isBooking(isBooking)
+                .build();
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/dto/SeatResponse.java
+++ b/ticket/src/main/java/comento/backend/ticket/dto/SeatResponse.java
@@ -1,0 +1,25 @@
+package comento.backend.ticket.dto;
+
+import comento.backend.ticket.domain.Seat;
+import lombok.Data;
+
+@Data
+public class SeatResponse {
+    private SeatType seatType;
+    private Integer seatNumber;
+    private boolean isBooking;
+
+    public SeatResponse(SeatType seatType, Integer seatNumber, boolean isBooking) {
+        this.seatType = seatType;
+        this.seatNumber = seatNumber;
+        this.isBooking = isBooking;
+    }
+
+    public static SeatResponse of(Seat seat){
+        return new SeatResponse(
+                seat.getSeatType(),
+                seat.getSeatNumber(),
+                seat.isBooking()
+        );
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/dto/SeatType.java
+++ b/ticket/src/main/java/comento/backend/ticket/dto/SeatType.java
@@ -1,0 +1,9 @@
+package comento.backend.ticket.dto;
+
+public enum SeatType {
+    VIP,
+    S,
+    A,
+    B,
+    C
+}

--- a/ticket/src/main/java/comento/backend/ticket/dto/UserDto.java
+++ b/ticket/src/main/java/comento/backend/ticket/dto/UserDto.java
@@ -1,0 +1,26 @@
+package comento.backend.ticket.dto;
+
+import comento.backend.ticket.domain.User;
+import lombok.Data;
+import lombok.Getter;
+
+import javax.validation.constraints.Email;
+
+@Getter
+@Data
+public class UserDto {
+    @Email
+    private String email;
+
+    public UserDto(){}
+
+    public UserDto(String email) {
+        this.email = email;
+    }
+
+    public User toEntity(){
+        return User.builder()
+                .email(email)
+                .build();
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/repository/BookingHistoryRepository.java
+++ b/ticket/src/main/java/comento/backend/ticket/repository/BookingHistoryRepository.java
@@ -1,0 +1,9 @@
+package comento.backend.ticket.repository;
+
+import comento.backend.ticket.domain.BookingHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BookingHistoryRepository extends JpaRepository<BookingHistory, Long> {
+}

--- a/ticket/src/main/java/comento/backend/ticket/repository/BookingRepository.java
+++ b/ticket/src/main/java/comento/backend/ticket/repository/BookingRepository.java
@@ -1,14 +1,20 @@
 package comento.backend.ticket.repository;
 
 import comento.backend.ticket.domain.Booking;
-import comento.backend.ticket.domain.User;
+import comento.backend.ticket.dto.BookingResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import java.util.*;
 
 @Repository
 public interface BookingRepository extends JpaRepository<Booking, Long> {
-
-    Optional<Booking> findByUser(User user);
+    /*해당 유저(u, ~@~)가 예약(b)한 공연 정보(p)와 좌석 정보(s) 조회*/
+    @Query("select new comento.backend.ticket.dto.BookingResponse(p.title, p.startDate, u.email, s.seatType, s.seatNumber, p.price) " +
+            "from Seat s join s.performance p on s.performance = p.id " +
+            "join Booking b on b.seat = s.id " +
+            "join User u on u.id = b.user " +
+            "where s.isBooking = :isBooking and u.email = :email")
+    List<BookingResponse> findMyBooking(boolean isBooking, String email);
 }

--- a/ticket/src/main/java/comento/backend/ticket/repository/BookingRepository.java
+++ b/ticket/src/main/java/comento/backend/ticket/repository/BookingRepository.java
@@ -1,0 +1,14 @@
+package comento.backend.ticket.repository;
+
+import comento.backend.ticket.domain.Booking;
+import comento.backend.ticket.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface BookingRepository extends JpaRepository<Booking, Long> {
+
+    Optional<Booking> findByUser(User user);
+}

--- a/ticket/src/main/java/comento/backend/ticket/repository/PerformanceRepository.java
+++ b/ticket/src/main/java/comento/backend/ticket/repository/PerformanceRepository.java
@@ -6,9 +6,11 @@ import org.springframework.stereotype.Repository;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PerformanceRepository extends JpaRepository<Performance, Long> {
     List<Performance> findByStartDateGreaterThanEqualOrderByStartDateAsc(Date startDate);
     List<Performance> findByTitleAndStartDateGreaterThanEqualOrderByStartDate(String title, Date startDate);
+    Optional<Performance> findByIdAndTitle(Long id, String title);
 }

--- a/ticket/src/main/java/comento/backend/ticket/repository/PerformanceRepository.java
+++ b/ticket/src/main/java/comento/backend/ticket/repository/PerformanceRepository.java
@@ -1,0 +1,14 @@
+package comento.backend.ticket.repository;
+
+import comento.backend.ticket.domain.Performance;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Date;
+import java.util.List;
+
+@Repository
+public interface PerformanceRepository extends JpaRepository<Performance, Long> {
+    List<Performance> findByStartDateGreaterThanEqualOrderByStartDateAsc(Date startDate);
+    List<Performance> findByTitleAndStartDateGreaterThanEqualOrderByStartDate(String title, Date startDate);
+}

--- a/ticket/src/main/java/comento/backend/ticket/repository/SeatRepository.java
+++ b/ticket/src/main/java/comento/backend/ticket/repository/SeatRepository.java
@@ -12,4 +12,6 @@ import java.util.*;
 public interface SeatRepository extends JpaRepository<Seat, Long> {
     List<Seat> findByPerformance(Performance performance);
     Optional<Seat> findByPerformanceAndSeatTypeAndSeatNumber(Performance performance, SeatType seatType, Integer seatNumber);
+    //isBooking 여부 확인을 위해 사용
+    Optional<Seat> findByPerformanceAndSeatTypeAndSeatNumberAndIsBooking(Performance performance, SeatType seatType, Integer seatNumber, boolean isBooking);
 }

--- a/ticket/src/main/java/comento/backend/ticket/repository/SeatRepository.java
+++ b/ticket/src/main/java/comento/backend/ticket/repository/SeatRepository.java
@@ -1,0 +1,15 @@
+package comento.backend.ticket.repository;
+
+import comento.backend.ticket.domain.Performance;
+import comento.backend.ticket.domain.Seat;
+import comento.backend.ticket.dto.SeatType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+
+@Repository
+public interface SeatRepository extends JpaRepository<Seat, Long> {
+    List<Seat> findByPerformance(Performance performance);
+    Optional<Seat> findByPerformanceAndSeatTypeAndSeatNumber(Performance performance, SeatType seatType, Integer seatNumber);
+}

--- a/ticket/src/main/java/comento/backend/ticket/repository/UserRepository.java
+++ b/ticket/src/main/java/comento/backend/ticket/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package comento.backend.ticket.repository;
+
+import comento.backend.ticket.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+}

--- a/ticket/src/main/java/comento/backend/ticket/service/BookingHistoryService.java
+++ b/ticket/src/main/java/comento/backend/ticket/service/BookingHistoryService.java
@@ -1,0 +1,20 @@
+package comento.backend.ticket.service;
+
+import comento.backend.ticket.domain.BookingHistory;
+import comento.backend.ticket.dto.BookingHistoryDto;
+import comento.backend.ticket.repository.BookingHistoryRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BookingHistoryService {
+    private final BookingHistoryRepository bookingHistoryRepository;
+
+    public BookingHistoryService(BookingHistoryRepository bookingHistoryRepository) {
+        this.bookingHistoryRepository = bookingHistoryRepository;
+    }
+
+    public BookingHistory saveBookingHistory(BookingHistoryDto bookingHistoryDto){
+        BookingHistory bookingHistory = bookingHistoryDto.toEntity();
+        return bookingHistoryRepository.save(bookingHistory);
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/service/BookingHistoryService.java
+++ b/ticket/src/main/java/comento/backend/ticket/service/BookingHistoryService.java
@@ -13,7 +13,7 @@ public class BookingHistoryService {
         this.bookingHistoryRepository = bookingHistoryRepository;
     }
 
-    public BookingHistory saveBookingHistory(BookingHistoryDto bookingHistoryDto){
+    public BookingHistory saveBookingHistory(final BookingHistoryDto bookingHistoryDto){
         BookingHistory bookingHistory = bookingHistoryDto.toEntity();
         return bookingHistoryRepository.save(bookingHistory);
     }

--- a/ticket/src/main/java/comento/backend/ticket/service/BookingService.java
+++ b/ticket/src/main/java/comento/backend/ticket/service/BookingService.java
@@ -40,7 +40,7 @@ public class BookingService {
         updateSeat(seat, performance, reqBooking);
 
         //seat의 값이 있다면, booking 가능
-        addBookingHistory(user, performance, seat);
+        saveBookingSucessLog(user, performance, seat);
 
         //booking 여부 insert
         Booking booking = reqBooking.toEntity(user, performance, seat);
@@ -58,7 +58,7 @@ public class BookingService {
         seatService.updateSeat(seatDto);
     }
 
-    private void addBookingHistory(final User user, final Performance performance, final Seat seat) {
+    private void saveBookingSucessLog(final User user, final Performance performance, final Seat seat) {
         //booking의 성공 여부 history 저장
         BookingHistoryDto bookingHistoryDto = BookingHistoryDto.builder()
                         .user(user)

--- a/ticket/src/main/java/comento/backend/ticket/service/BookingService.java
+++ b/ticket/src/main/java/comento/backend/ticket/service/BookingService.java
@@ -1,51 +1,81 @@
 package comento.backend.ticket.service;
 
-import comento.backend.ticket.domain.Booking;
-import comento.backend.ticket.domain.Performance;
-import comento.backend.ticket.domain.Seat;
-import comento.backend.ticket.domain.User;
-import comento.backend.ticket.dto.BookingDto;
-import comento.backend.ticket.dto.SeatDto;
+import comento.backend.ticket.config.customException.NotFoundDataException;
+import comento.backend.ticket.domain.*;
+import comento.backend.ticket.dto.*;
 import comento.backend.ticket.repository.BookingRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 public class BookingService {
     private final BookingRepository bookingRepository;
     private final PerformanceService performanceService;
+    private final BookingHistoryService bookingHistoryService;
     private final UserService userService;
     private final SeatService seatService;
 
-    public BookingService(BookingRepository bookingRepository, PerformanceService performanceService, UserService userService, SeatService seatService) {
+    public BookingService(BookingRepository bookingRepository, PerformanceService performanceService,
+                          BookingHistoryService bookingHistoryService, UserService userService,
+                          SeatService seatService) {
         this.bookingRepository = bookingRepository;
         this.performanceService = performanceService;
+        this.bookingHistoryService = bookingHistoryService;
         this.userService = userService;
         this.seatService = seatService;
     }
 
-    // @TODO : VIP, 3이 여러 개 저장되는 이슈 해결 해야 함 (동시성 문제)
-    //예약 정보 저장하고, Seat 정보에는 is_booking을 true로 변경
-    public Booking saveBookging(BookingDto reqBooking){
-        User user = userService.getUser(reqBooking.getEmail());
-        Performance performance = performanceService.getPerformance(reqBooking.getId(), reqBooking.getTitle());
-        Seat seat = seatService.getSeat(performance, reqBooking.getSeatType(), reqBooking.getSeatNumber());
-
-        reqBooking.setUser(user);
-        reqBooking.setPerformance(performance);
-        reqBooking.setSeat(seat);
+    // @TODO : 동시성 문제 해결해야 함
+    //예약 정보를 booking에 저장하고, Seat 정보에는 is_booking을 true로 변경
+    @Transactional
+    public Booking saveBookging(final BookingDto reqBooking){
+        final User user = userService.getUser(reqBooking.getEmail());
+        final Performance performance = performanceService.getPerformance(reqBooking.getId(), reqBooking.getTitle());
+        final Seat seat = seatService.getIsBooking(user, performance, reqBooking.getSeatType(), reqBooking.getSeatNumber(), false); //false라면 예약 가능
 
         //seat 테이블의 is_booking 칼럼을 true로 update
-        SeatDto seatDto = new SeatDto(seat.getId(), performance, reqBooking.getSeatType(), reqBooking.getSeatNumber(), true);
-        seatService.updateSeat(seatDto);
+        updateSeat(seat, performance, reqBooking);
 
-        Booking booking = reqBooking.toEntity();
+        //seat의 값이 있다면, booking 가능
+        addBookingHistory(user, performance, seat);
+
+        //booking 여부 insert
+        Booking booking = reqBooking.toEntity(user, performance, seat);
         return bookingRepository.save(booking);
     }
 
-    public Optional<Booking> getMyBooking(String email){
+    private void updateSeat(final Seat seat, final Performance performance, final BookingDto reqBooking) {
+        SeatDto seatDto = SeatDto.builder()
+                .seat_id(seat.getId())
+                .performance(performance)
+                .seatType(reqBooking.getSeatType())
+                .seatNumber(reqBooking.getSeatNumber())
+                .isBooking(true)
+                .build();
+        seatService.updateSeat(seatDto);
+    }
 
-        return null;
+    private void addBookingHistory(final User user, final Performance performance, final Seat seat) {
+        //booking의 성공 여부 history 저장
+        BookingHistoryDto bookingHistoryDto = BookingHistoryDto.builder()
+                        .user(user)
+                        .performance(performance)
+                        .seat(seat)
+                        .isSuccess(true)
+                        .build();
+        bookingHistoryService.saveBookingHistory(bookingHistoryDto);
+    }
+
+    @Transactional(readOnly = true)
+    public List<BookingResponse> getMyBooking(String email){
+        User user = userService.getUser(email);
+        List<BookingResponse> result = bookingRepository.findMyBooking(true, user.getEmail());
+        if(result.isEmpty()){
+            throw new NotFoundDataException();
+        }
+        return result;
     }
 }

--- a/ticket/src/main/java/comento/backend/ticket/service/BookingService.java
+++ b/ticket/src/main/java/comento/backend/ticket/service/BookingService.java
@@ -1,0 +1,51 @@
+package comento.backend.ticket.service;
+
+import comento.backend.ticket.domain.Booking;
+import comento.backend.ticket.domain.Performance;
+import comento.backend.ticket.domain.Seat;
+import comento.backend.ticket.domain.User;
+import comento.backend.ticket.dto.BookingDto;
+import comento.backend.ticket.dto.SeatDto;
+import comento.backend.ticket.repository.BookingRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class BookingService {
+    private final BookingRepository bookingRepository;
+    private final PerformanceService performanceService;
+    private final UserService userService;
+    private final SeatService seatService;
+
+    public BookingService(BookingRepository bookingRepository, PerformanceService performanceService, UserService userService, SeatService seatService) {
+        this.bookingRepository = bookingRepository;
+        this.performanceService = performanceService;
+        this.userService = userService;
+        this.seatService = seatService;
+    }
+
+    // @TODO : VIP, 3이 여러 개 저장되는 이슈 해결 해야 함 (동시성 문제)
+    //예약 정보 저장하고, Seat 정보에는 is_booking을 true로 변경
+    public Booking saveBookging(BookingDto reqBooking){
+        User user = userService.getUser(reqBooking.getEmail());
+        Performance performance = performanceService.getPerformance(reqBooking.getId(), reqBooking.getTitle());
+        Seat seat = seatService.getSeat(performance, reqBooking.getSeatType(), reqBooking.getSeatNumber());
+
+        reqBooking.setUser(user);
+        reqBooking.setPerformance(performance);
+        reqBooking.setSeat(seat);
+
+        //seat 테이블의 is_booking 칼럼을 true로 update
+        SeatDto seatDto = new SeatDto(seat.getId(), performance, reqBooking.getSeatType(), reqBooking.getSeatNumber(), true);
+        seatService.updateSeat(seatDto);
+
+        Booking booking = reqBooking.toEntity();
+        return bookingRepository.save(booking);
+    }
+
+    public Optional<Booking> getMyBooking(String email){
+
+        return null;
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/service/PerformanceService.java
+++ b/ticket/src/main/java/comento/backend/ticket/service/PerformanceService.java
@@ -20,7 +20,7 @@ public class PerformanceService {
         this.performanceRepository = performanceRepository;
     }
 
-    public List<PerformanceResponse> getListPerformance(PerformanceDto performanceDto){
+    public List<PerformanceResponse> getListPerformance(final PerformanceDto performanceDto){
         Date startDate = performanceDto.getStartDate();
         String title = performanceDto.getTitle();
         List<Performance> result = title != null ?
@@ -32,7 +32,7 @@ public class PerformanceService {
         return result.stream().map(PerformanceResponse::of).collect(Collectors.toList());
     }
 
-    public Performance getPerformance(Long id, String title){
+    public Performance getPerformance(final Long id, final String title){
         Optional<Performance> performance = performanceRepository.findByIdAndTitle(id, title);
         return performance.orElseThrow(NotFoundDataException::new);
     }

--- a/ticket/src/main/java/comento/backend/ticket/service/PerformanceService.java
+++ b/ticket/src/main/java/comento/backend/ticket/service/PerformanceService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Date;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -29,5 +30,10 @@ public class PerformanceService {
             throw new NotFoundDataException();
         }
         return result.stream().map(PerformanceResponse::of).collect(Collectors.toList());
+    }
+
+    public Performance getPerformance(Long id, String title){
+        Optional<Performance> performance = performanceRepository.findByIdAndTitle(id, title);
+        return performance.orElseThrow(NotFoundDataException::new);
     }
 }

--- a/ticket/src/main/java/comento/backend/ticket/service/PerformanceService.java
+++ b/ticket/src/main/java/comento/backend/ticket/service/PerformanceService.java
@@ -1,0 +1,33 @@
+package comento.backend.ticket.service;
+
+import comento.backend.ticket.config.customException.NotFoundDataException;
+import comento.backend.ticket.domain.Performance;
+import comento.backend.ticket.dto.PerformanceDto;
+import comento.backend.ticket.dto.PerformanceResponse;
+import comento.backend.ticket.repository.PerformanceRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Service
+public class PerformanceService {
+    private final PerformanceRepository performanceRepository;
+
+    public PerformanceService(PerformanceRepository performanceRepository) {
+        this.performanceRepository = performanceRepository;
+    }
+
+    public List<PerformanceResponse> getListPerformance(PerformanceDto performanceDto){
+        Date startDate = performanceDto.getStartDate();
+        String title = performanceDto.getTitle();
+        List<Performance> result = title != null ?
+                performanceRepository.findByTitleAndStartDateGreaterThanEqualOrderByStartDate(title, startDate) :
+                performanceRepository.findByStartDateGreaterThanEqualOrderByStartDateAsc(startDate);
+        if(result.isEmpty()){
+            throw new NotFoundDataException();
+        }
+        return result.stream().map(PerformanceResponse::of).collect(Collectors.toList());
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/service/SeatService.java
+++ b/ticket/src/main/java/comento/backend/ticket/service/SeatService.java
@@ -1,14 +1,12 @@
 package comento.backend.ticket.service;
 
+import comento.backend.ticket.config.customException.DuplicatedException;
 import comento.backend.ticket.config.customException.NotFoundDataException;
 import comento.backend.ticket.domain.Performance;
 import comento.backend.ticket.domain.Seat;
-import comento.backend.ticket.dto.PerformanceResponse;
-import comento.backend.ticket.dto.SeatDto;
-import comento.backend.ticket.dto.SeatResponse;
-import comento.backend.ticket.dto.SeatType;
+import comento.backend.ticket.domain.User;
+import comento.backend.ticket.dto.*;
 import comento.backend.ticket.repository.SeatRepository;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -18,12 +16,14 @@ import java.util.stream.Collectors;
 @Service
 public class SeatService {
     private final SeatRepository seatRepository;
+    private final BookingHistoryService bookingHistoryService;
 
-    public SeatService(SeatRepository seatRepository) {
+    public SeatService(SeatRepository seatRepository, BookingHistoryService bookingHistoryService) {
         this.seatRepository = seatRepository;
+        this.bookingHistoryService = bookingHistoryService;
     }
 
-    public List<SeatResponse> getListPerformanceSeat(PerformanceResponse performanceData) {
+    public List<SeatResponse> getListPerformanceSeat(final PerformanceResponse performanceData) {
         Performance performance = new Performance();
         performance.setId(performanceData.getId());
         List<Seat> seatResult =  seatRepository.findByPerformance(performance);
@@ -33,13 +33,32 @@ public class SeatService {
         return seatResult.stream().map(SeatResponse::of).collect(Collectors.toList());
     }
 
-    public Seat getSeat(Performance performance, SeatType seatType, Integer seatNumber) {
-        Optional<Seat> seat = seatRepository.findByPerformanceAndSeatTypeAndSeatNumber(performance, seatType, seatNumber);
-        return seat.orElseThrow(NotFoundDataException::new);
-    }
-
-    public Seat updateSeat(SeatDto seatDto) {
+    public Seat updateSeat(final SeatDto seatDto) {
         Seat seat = seatDto.toEntity();
         return seatRepository.save(seat);
+    }
+
+    // @TODO : insert 쿼리도 출력되고, 예외도 발생하지만 BookingHisotry 테이블에 새 데이터 insert가 안된다 ..
+    public Seat getIsBooking(final User user, final Performance performance, final SeatType seatType, final Integer seatNumber, final boolean isBooking) {
+        Optional<Seat> seatIsBooking = seatRepository.findByPerformanceAndSeatTypeAndSeatNumberAndIsBooking(performance, seatType, seatNumber, isBooking);
+        final Seat seat = getSeat(performance, seatType, seatNumber); //seat 번호를 위해서 필요
+        return seatIsBooking.orElseGet(() -> {
+           //실패 여부 BookingHistory에 저장
+            BookingHistoryDto bookingHistoryDto = BookingHistoryDto.builder()
+                    .id(null)
+                    .user(user)
+                    .performance(performance)
+                    .seat(seat)
+                    .isSuccess(false)
+                    .build();
+            bookingHistoryService.saveBookingHistory(bookingHistoryDto);
+           //예외 전달
+            throw new DuplicatedException("SeatService");
+        });
+    }
+
+    public Seat getSeat(Performance performance, SeatType seatType, Integer seatNumber) {
+        Optional<Seat> seat = seatRepository.findByPerformanceAndSeatTypeAndSeatNumber(performance, seatType, seatNumber);
+        return seat.orElse(seat.get());
     }
 }

--- a/ticket/src/main/java/comento/backend/ticket/service/SeatService.java
+++ b/ticket/src/main/java/comento/backend/ticket/service/SeatService.java
@@ -1,0 +1,45 @@
+package comento.backend.ticket.service;
+
+import comento.backend.ticket.config.customException.NotFoundDataException;
+import comento.backend.ticket.domain.Performance;
+import comento.backend.ticket.domain.Seat;
+import comento.backend.ticket.dto.PerformanceResponse;
+import comento.backend.ticket.dto.SeatDto;
+import comento.backend.ticket.dto.SeatResponse;
+import comento.backend.ticket.dto.SeatType;
+import comento.backend.ticket.repository.SeatRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class SeatService {
+    private final SeatRepository seatRepository;
+
+    public SeatService(SeatRepository seatRepository) {
+        this.seatRepository = seatRepository;
+    }
+
+    public List<SeatResponse> getListPerformanceSeat(PerformanceResponse performanceData) {
+        Performance performance = new Performance();
+        performance.setId(performanceData.getId());
+        List<Seat> seatResult =  seatRepository.findByPerformance(performance);
+        if(seatResult.isEmpty()){
+            throw new NotFoundDataException();
+        }
+        return seatResult.stream().map(SeatResponse::of).collect(Collectors.toList());
+    }
+
+    public Seat getSeat(Performance performance, SeatType seatType, Integer seatNumber) {
+        Optional<Seat> seat = seatRepository.findByPerformanceAndSeatTypeAndSeatNumber(performance, seatType, seatNumber);
+        return seat.orElseThrow(NotFoundDataException::new);
+    }
+
+    public Seat updateSeat(SeatDto seatDto) {
+        Seat seat = seatDto.toEntity();
+        return seatRepository.save(seat);
+    }
+}

--- a/ticket/src/main/java/comento/backend/ticket/service/SeatService.java
+++ b/ticket/src/main/java/comento/backend/ticket/service/SeatService.java
@@ -8,8 +8,10 @@ import comento.backend.ticket.domain.User;
 import comento.backend.ticket.dto.*;
 import comento.backend.ticket.repository.SeatRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -23,6 +25,7 @@ public class SeatService {
         this.bookingHistoryService = bookingHistoryService;
     }
 
+    @Transactional(readOnly = true)
     public List<SeatResponse> getListPerformanceSeat(final PerformanceResponse performanceData) {
         Performance performance = new Performance();
         performance.setId(performanceData.getId());
@@ -39,26 +42,26 @@ public class SeatService {
     }
 
     // @TODO : insert 쿼리도 출력되고, 예외도 발생하지만 BookingHisotry 테이블에 새 데이터 insert가 안된다 ..
+    @Transactional
     public Seat getIsBooking(final User user, final Performance performance, final SeatType seatType, final Integer seatNumber, final boolean isBooking) {
-        Optional<Seat> seatIsBooking = seatRepository.findByPerformanceAndSeatTypeAndSeatNumberAndIsBooking(performance, seatType, seatNumber, isBooking);
-        final Seat seat = getSeat(performance, seatType, seatNumber); //seat 번호를 위해서 필요
-        return seatIsBooking.orElseGet(() -> {
-           //실패 여부 BookingHistory에 저장
-            BookingHistoryDto bookingHistoryDto = BookingHistoryDto.builder()
-                    .id(null)
-                    .user(user)
-                    .performance(performance)
-                    .seat(seat)
-                    .isSuccess(false)
-                    .build();
-            bookingHistoryService.saveBookingHistory(bookingHistoryDto);
-           //예외 전달
+        Seat seatIsBooking = seatRepository.findByPerformanceAndSeatTypeAndSeatNumberAndIsBooking(performance, seatType, seatNumber, isBooking)
+                .orElseGet(()-> null);
+        if(Objects.isNull(seatIsBooking)){
+            saveBookingFailLog(user, performance, null);
             throw new DuplicatedException("SeatService");
-        });
+        }
+        return seatIsBooking;
     }
 
-    public Seat getSeat(Performance performance, SeatType seatType, Integer seatNumber) {
-        Optional<Seat> seat = seatRepository.findByPerformanceAndSeatTypeAndSeatNumber(performance, seatType, seatNumber);
-        return seat.orElse(seat.get());
+    private void saveBookingFailLog(final User user, final Performance performance, final Seat seat) {
+        //실패 여부 BookingHistory에 저장
+        BookingHistoryDto bookingHistoryDto = BookingHistoryDto.builder()
+                .id(null)
+                .user(user)
+                .performance(performance)
+                .seat(seat)
+                .isSuccess(false)
+                .build();
+        bookingHistoryService.saveBookingHistory(bookingHistoryDto);
     }
 }

--- a/ticket/src/main/java/comento/backend/ticket/service/UserService.java
+++ b/ticket/src/main/java/comento/backend/ticket/service/UserService.java
@@ -1,12 +1,14 @@
 package comento.backend.ticket.service;
 
 import comento.backend.ticket.config.customException.DuplicatedException;
+import comento.backend.ticket.config.customException.NoAuthException;
 import comento.backend.ticket.domain.User;
 import comento.backend.ticket.dto.UserDto;
 import comento.backend.ticket.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.Objects;
+import java.util.Optional;
 
 
 @Service
@@ -30,5 +32,10 @@ public class UserService {
     private boolean checkEmailDuplicate(String email){
         User user = userRepository.findByEmail(email).orElseGet(()->null);
         return Objects.isNull(user); //null이면 true
+    }
+
+    public User getUser(String email){
+        Optional<User> user = userRepository.findByEmail(email);
+        return user.orElseThrow(NoAuthException::new);
     }
 }

--- a/ticket/src/main/java/comento/backend/ticket/service/UserService.java
+++ b/ticket/src/main/java/comento/backend/ticket/service/UserService.java
@@ -19,7 +19,7 @@ public class UserService {
         this.userRepository = userRepository;
     }
 
-    public User saveUser(UserDto userDto){
+    public User saveUser(final UserDto userDto){
         User user = userDto.toEntity();
 
         if(!checkEmailDuplicate(user.getEmail())) {
@@ -29,12 +29,12 @@ public class UserService {
         return userRepository.save(user);
     }
 
-    private boolean checkEmailDuplicate(String email){
+    private boolean checkEmailDuplicate(final String email){
         User user = userRepository.findByEmail(email).orElseGet(()->null);
         return Objects.isNull(user); //null이면 true
     }
 
-    public User getUser(String email){
+    public User getUser(final String email){
         Optional<User> user = userRepository.findByEmail(email);
         return user.orElseThrow(NoAuthException::new);
     }

--- a/ticket/src/main/java/comento/backend/ticket/service/UserService.java
+++ b/ticket/src/main/java/comento/backend/ticket/service/UserService.java
@@ -1,0 +1,34 @@
+package comento.backend.ticket.service;
+
+import comento.backend.ticket.config.customException.DuplicatedException;
+import comento.backend.ticket.domain.User;
+import comento.backend.ticket.dto.UserDto;
+import comento.backend.ticket.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public User saveUser(UserDto userDto){
+        User user = userDto.toEntity();
+
+        if(!checkEmailDuplicate(user.getEmail())) {
+            throw new DuplicatedException("UserService");
+        }
+
+        return userRepository.save(user);
+    }
+
+    private boolean checkEmailDuplicate(String email){
+        User user = userRepository.findByEmail(email).orElseGet(()->null);
+        return Objects.isNull(user); //null이면 true
+    }
+}

--- a/ticket/src/main/resources/logback.xml
+++ b/ticket/src/main/resources/logback.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <property name="LOG_PATTERN" value = "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n" />
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
+
+    <!-- appender : log의 형태 설정, log 메세지가 출력될 대상(console/file)결정 -->
+    <appender name="ROLLING_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/ticket-reservation-server.log</file>
+        <rollingPolicy class = "ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- 일자별 로그파일 생성 -->
+            <fileNamePattern>logs/ticket-reservation-server-%d{yyyy-MM-dd}.log</fileNamePattern>
+            <!-- 최대 보관주기. 30일 이상된 파일은 자동으로 제거 -->
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- INFO 이상 level 출력 -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+    <logger name="org.springframework" level="warn">
+        <appender-ref ref = "ROLLING_FILE"/>
+    </logger>
+</configuration>

--- a/ticket/src/test/java/comento/backend/ticket/repository/PerformanceRepositroyTest.java
+++ b/ticket/src/test/java/comento/backend/ticket/repository/PerformanceRepositroyTest.java
@@ -1,0 +1,89 @@
+package comento.backend.ticket.repository;
+
+import comento.backend.ticket.config.customException.NotFoundDataException;
+import comento.backend.ticket.domain.Performance;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class PerformanceRepositroyTest {
+    private final PerformanceRepository performanceRepository;
+
+    @Autowired
+    public PerformanceRepositroyTest(PerformanceRepository performanceRepository) {
+        this.performanceRepository = performanceRepository;
+    }
+
+    //Junit5 부터 접근제어자 생략 가능 (JUnit4 까지는 public이어야 했음!)
+
+    @Test
+    @DisplayName("[성공] 날짜를 정확하게 입력한 경우")
+    void 공연_날짜_정보_조회() throws ParseException {
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("2020-06-20");
+
+        List<Performance> result = performanceRepository.findByStartDateGreaterThanEqualOrderByStartDateAsc(startDate);
+
+        assertThat(result.size()).isNotZero();
+    }
+
+    @Test
+    @DisplayName("[성공] 날짜, 공연제목을 정확하게 입력한 경우")
+    void 공연_날짜이름_정보_조회() throws ParseException {
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("2020-06-20");
+        String title = "국립무용단 <산조>";
+
+        List<Performance> result = performanceRepository.findByTitleAndStartDateGreaterThanEqualOrderByStartDate(title, startDate);
+
+        assertThat(result.size()).isNotZero();
+    }
+
+    @Test
+    @DisplayName("[실패] NOT FOUND ERROR")
+    void 공연_날짜_정보_조회실패() throws ParseException, NotFoundDataException {
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("2021-06-31");
+
+        List<Performance> result = performanceRepository.findByStartDateGreaterThanEqualOrderByStartDateAsc(startDate);
+
+        assertThat(result).isNull();
+
+        /*앙댐
+        //given
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("2021-06-31");
+
+        //when
+        final NotFoundDataException exception = assertThrows(NotFoundDataException.class, () -> {
+            performanceRepository.findByStartDateGreaterThanEqualOrderByStartDateAsc(startDate);
+        });
+
+        //then
+        assertThat(exception.getMessage()).isNotNull();
+        */
+    }
+
+    @Test
+    @DisplayName("[실패] BAD REQUEST")
+    void 공연_날짜이름_정보_조회실패() throws ParseException {
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("ㄴ");
+        String title = "국립무용단 <산조>";
+
+        List<Performance> result = performanceRepository.findByTitleAndStartDateGreaterThanEqualOrderByStartDate(title, startDate);
+
+        assertThat(result).isNull();
+    }
+}

--- a/ticket/src/test/java/comento/backend/ticket/repository/SeatRepositoryTest.java
+++ b/ticket/src/test/java/comento/backend/ticket/repository/SeatRepositoryTest.java
@@ -1,0 +1,42 @@
+package comento.backend.ticket.repository;
+
+import comento.backend.ticket.domain.Performance;
+import comento.backend.ticket.domain.Seat;
+import comento.backend.ticket.dto.SeatType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class SeatRepositoryTest {
+    private final SeatRepository seatRepository;
+
+    @Autowired
+    public SeatRepositoryTest(SeatRepository seatRepository) {
+        this.seatRepository = seatRepository;
+    }
+
+    @Test
+    @DisplayName("조회를 성공한다면 ID값을 가져온다.")
+    void seat_정보_조회() throws ParseException {
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date date = format.parse("2021-06-20");
+        Performance performance = new Performance(1L, "2021 정오의 음악회 5월", "국악", date, date,
+                "전석 20,000원", "국립극장\n하늘극장\n8세 이상 관람가", "70분");
+
+        Optional<Seat> result = seatRepository.findByPerformanceAndSeatTypeAndSeatNumber(performance, SeatType.VIP, 2);
+
+        assertThat(result.get().getId()).isNotZero();
+    }
+}

--- a/ticket/src/test/java/comento/backend/ticket/repository/UserRepositryTest.java
+++ b/ticket/src/test/java/comento/backend/ticket/repository/UserRepositryTest.java
@@ -1,0 +1,53 @@
+package comento.backend.ticket.repository;
+
+import comento.backend.ticket.domain.User;
+import comento.backend.ticket.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import static org.assertj.core.api.Assertions.assertThat;
+
+//given
+//when
+//then
+
+@SpringBootTest
+@Transactional
+public class UserRepositryTest {
+    private final UserRepository userRepository;
+
+    @Autowired
+    public UserRepositryTest(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Test
+    @DisplayName("이메일을 입력하면 사용자 등록에 성공하여 DB에 저장한다.")
+    public void 사용자_등록_성공(){
+        //given
+        User user = new User();
+        user.setEmail("kimhyejung12@naver.com");
+
+        //when
+        User result = userRepository.save(user);
+
+        //then
+        assertThat(result.getId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("이메일을 입력하면 사용자 등록에 성공하여 DB에 저장한다.")
+    public void 사용자_등록_중복으로_인한_실패(){
+        //given
+        User user = new User();
+        user.setEmail("kimhyejung12@naver.com"); //error 409
+
+        //when
+        User result = userRepository.save(user);
+
+        //then
+        assertThat(result.getId()).isNotNull();
+    }
+}

--- a/ticket/src/test/java/comento/backend/ticket/service/MockPerformanceServiceTest.java
+++ b/ticket/src/test/java/comento/backend/ticket/service/MockPerformanceServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -24,8 +25,9 @@ import static org.mockito.Mockito.verify; //해당 기능이 사용되었는지 
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Transactional
 @ExtendWith(MockitoExtension.class) //JUnit5와 Mockito 연동
-public class PerformanceServiceTest2 {
+public class MockPerformanceServiceTest {
 
     @Mock //mock객체로 생성
     private PerformanceRepository performanceRepository;
@@ -55,9 +57,8 @@ public class PerformanceServiceTest2 {
         });
         //then
         String msg = nfde.getMessage();
-        assertThat(msg).isEqualTo(null);
+        assertThat(msg).isNull();
     }
-    //@TODO : 성공해야 하는데 두 테스트 메소드 모두 NotFoundDataException 발생,,
     @Test
     @DisplayName("[성공] 날짜를 정확히 입력한 경우")
     void 공연정보가_있으면_응답한다1() throws ParseException {
@@ -71,6 +72,7 @@ public class PerformanceServiceTest2 {
         List<PerformanceResponse> result =  performanceService.getListPerformance(new PerformanceDto(null, startDate));
 
         //then
+        System.out.println(result);
         assertThat(result.size()).isNotZero(); //2개
     }
     @Test
@@ -80,13 +82,14 @@ public class PerformanceServiceTest2 {
         DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         Date startDate = format.parse("2021-06-20");
         String title = "국립무용단 <산조>";
-        List<Performance> temp = new ArrayList<>();
+        PerformanceDto dto = new PerformanceDto(title, startDate);
         given(performanceRepository.findByTitleAndStartDateGreaterThanEqualOrderByStartDate(title, startDate))
-                .willReturn(temp);
+                .willReturn(new ArrayList<>());
         //when
-        List<PerformanceResponse> result = performanceService.getListPerformance(new PerformanceDto(title, startDate));
+        List<PerformanceResponse> result = performanceService.getListPerformance(dto);
 
         //then
+        System.out.println(result);
         assertThat(result.size()).isNotZero();
     }
 }

--- a/ticket/src/test/java/comento/backend/ticket/service/MockPerformanceServiceTest.java
+++ b/ticket/src/test/java/comento/backend/ticket/service/MockPerformanceServiceTest.java
@@ -49,7 +49,7 @@ public class MockPerformanceServiceTest {
         //performanceRepository를 mock했으니 테스트 상황에서 원하는 결과를 새롭게 구현하는 코드.
         //테스트가 돌아가는 동안에는 willReturn에서 반환하는 결과를 반드시 return하므로 PerformanceRepository를 의존하지 않고도 돌아가는 테스트코드가 완성
         given(performanceRepository.findByStartDateGreaterThanEqualOrderByStartDateAsc(startDate))
-                .willReturn(new ArrayList<Performance>());
+                .willReturn(new ArrayList<Performance>()); //빈 배열 반환
         //when
         //공연정보가 없는 경우 Service에서는 NOT FOUND ERROR 예외 호출
         NotFoundDataException nfde = assertThrows(NotFoundDataException.class, () -> {
@@ -67,13 +67,12 @@ public class MockPerformanceServiceTest {
         Date startDate = format.parse("2021-06-20");
 
         given(performanceRepository.findByStartDateGreaterThanEqualOrderByStartDateAsc(startDate))
-                .willReturn(new ArrayList<>());
+                .willReturn(PerformanceFixture.performances(startDate));
         //when
         List<PerformanceResponse> result =  performanceService.getListPerformance(new PerformanceDto(null, startDate));
 
         //then
-        System.out.println(result);
-        assertThat(result.size()).isNotZero(); //2개
+        assertThat(result.size()).isNotZero();
     }
     @Test
     @DisplayName("[성공] 날짜, 제목을 정확히 입력한 경우")
@@ -84,12 +83,47 @@ public class MockPerformanceServiceTest {
         String title = "국립무용단 <산조>";
         PerformanceDto dto = new PerformanceDto(title, startDate);
         given(performanceRepository.findByTitleAndStartDateGreaterThanEqualOrderByStartDate(title, startDate))
-                .willReturn(new ArrayList<>());
+                .willReturn(PerformanceFixture.performances(startDate, title));
         //when
         List<PerformanceResponse> result = performanceService.getListPerformance(dto);
 
         //then
-        System.out.println(result);
         assertThat(result.size()).isNotZero();
+    }
+    private static class PerformanceFixture {
+        public static List<Performance> performances(final Date date) {
+            List<Performance> performances = new ArrayList<>();
+            performances.add(performance(date));
+            return performances;
+        }
+        public static List<Performance> performances(final Date date, final String title) {
+            List<Performance> performances = new ArrayList<>();
+            performances.add(performance(date, title));
+            return performances;
+        }
+        public static Performance performance(final Date startDate) {
+            return Performance.builder()
+                    .id(null)
+                    .title(null)
+                    .startDate(startDate)
+                    .endDate(null)
+                    .genere(null)
+                    .description(null)
+                    .price(null)
+                    .runningTime(null)
+                    .build();
+        }
+        public static Performance performance(final Date startDate, final String title) {
+            return Performance.builder()
+                    .id(null)
+                    .title(title)
+                    .startDate(startDate)
+                    .endDate(null)
+                    .genere(null)
+                    .description(null)
+                    .price(null)
+                    .runningTime(null)
+                    .build();
+        }
     }
 }

--- a/ticket/src/test/java/comento/backend/ticket/service/MockSeatServiceTest.java
+++ b/ticket/src/test/java/comento/backend/ticket/service/MockSeatServiceTest.java
@@ -1,0 +1,76 @@
+package comento.backend.ticket.service;
+
+import comento.backend.ticket.config.customException.NotFoundDataException;
+import comento.backend.ticket.domain.Performance;
+import comento.backend.ticket.domain.Seat;
+import comento.backend.ticket.dto.PerformanceDto;
+import comento.backend.ticket.dto.PerformanceResponse;
+import comento.backend.ticket.dto.SeatResponse;
+import comento.backend.ticket.repository.SeatRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+public class MockSeatServiceTest {
+    @Mock //mock객체로 생성
+    private SeatRepository seatRepository;
+
+    private SeatService seatService;
+
+    @BeforeEach
+    void init() {
+        seatService = new SeatService(seatRepository); //mock 주입
+    }
+    @Test
+    @DisplayName("[실패] 404 NOT FOUND ERROR")
+    void 좌석_정보가_없으면_예외를_던진다() {
+        //given
+        Long id = 1L;
+
+        given(seatRepository.findByPerformanceId(id))
+                .willReturn(new ArrayList<Seat>());
+        //when
+        NotFoundDataException nfde = assertThrows(NotFoundDataException.class, () -> {
+            seatService.getListPerformanceSeat(id);
+        });
+        //then
+        String msg = nfde.getMessage();
+        assertThat(msg).isEqualTo(null);
+    }
+    @Test
+    @DisplayName("[성공]")
+    void 좌석_정보를_보여준다() throws ParseException {
+        //given
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date date = format.parse("2021-06-20");
+        PerformanceResponse performanceResponse = new PerformanceResponse(1L, "2021 정오의 음악회 5월", date, date,
+                "전석 20,000원", "국악", "국립극장\n하늘극장\n8세 이상 관람가", "70분");
+
+        Performance performance = new Performance();
+        performance.setId(performanceResponse.getId());
+
+        given(seatRepository.findByPerformance(performance))
+                .willReturn(new ArrayList<Seat>());
+        //when
+        List<SeatResponse> list =  seatService.getListPerformanceSeat(performanceResponse);
+
+        //then
+        assertThat(list.size()).isNotZero();
+    }
+}

--- a/ticket/src/test/java/comento/backend/ticket/service/PerformanceServiceTest.java
+++ b/ticket/src/test/java/comento/backend/ticket/service/PerformanceServiceTest.java
@@ -1,0 +1,82 @@
+package comento.backend.ticket.service;
+
+import comento.backend.ticket.domain.Performance;
+import comento.backend.ticket.dto.PerformanceDto;
+import comento.backend.ticket.dto.PerformanceResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest //통합테스트
+@Transactional
+public class PerformanceServiceTest {
+    private final PerformanceService performanceService;
+
+    @Autowired
+    public PerformanceServiceTest(PerformanceService performanceService) {
+        this.performanceService = performanceService;
+    }
+
+    @Test
+    @DisplayName("[성공] 날짜를 정확하게 입력한 경우")
+    void 공연_날짜_정보_조회() throws ParseException {
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("2021-06-20");
+
+        PerformanceDto dto = new PerformanceDto(null, startDate);
+
+        List<PerformanceResponse> result = performanceService.getListPerformance(dto);
+
+        assertThat(result.size()).isNotZero();
+    }
+
+    @Test
+    @DisplayName("[성공] 날짜, 공연제목을 정확하게 입력한 경우")
+    void 공연_날짜이름_정보_조회() throws ParseException {
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("2021-06-20");
+        String title = "국립무용단 <산조>";
+
+        PerformanceDto dto = new PerformanceDto(title, startDate);
+
+        List<PerformanceResponse> result = performanceService.getListPerformance(dto);
+
+        assertThat(result.size()).isNotZero();
+    }
+
+    @Test
+    @DisplayName("[실패] NOT FOUND ERROR")
+    void 공연_날짜_정보_조회실패() throws ParseException {
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("2021-06-31");
+        String title = "국립무용단 <산조>";
+
+        PerformanceDto dto = new PerformanceDto(title, startDate);
+
+        List<PerformanceResponse> result = performanceService.getListPerformance(dto);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("[실패] BAD REQUEST")
+    void 공연_날짜이름_정보_조회실패() throws ParseException {
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("S");
+        String title = "국립무용단 <산조>";
+
+        PerformanceDto dto = new PerformanceDto(title, startDate);
+
+        List<PerformanceResponse> result = performanceService.getListPerformance(dto);
+        assertThat(result).isNull();
+    }
+}

--- a/ticket/src/test/java/comento/backend/ticket/service/PerformanceServiceTest2.java
+++ b/ticket/src/test/java/comento/backend/ticket/service/PerformanceServiceTest2.java
@@ -1,0 +1,92 @@
+package comento.backend.ticket.service;
+
+import comento.backend.ticket.config.customException.NotFoundDataException;
+import comento.backend.ticket.domain.Performance;
+import comento.backend.ticket.dto.PerformanceDto;
+import comento.backend.ticket.dto.PerformanceResponse;
+import comento.backend.ticket.repository.PerformanceRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times; //몇 번 호출되었는지 검증
+import static org.mockito.Mockito.verify; //해당 기능이 사용되었는지 검증
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class) //JUnit5와 Mockito 연동
+public class PerformanceServiceTest2 {
+
+    @Mock //mock객체로 생성
+    private PerformanceRepository performanceRepository;
+
+    private PerformanceService performanceService;
+
+    @BeforeEach
+    void init() {
+        //실제 존재하는 performanceRepository가 주입되는것이 아닌 Mock PerformanceRepository가 주입
+        performanceService = new PerformanceService(performanceRepository);
+    }
+    @Test
+    @DisplayName("[실패] 없는 날짜 정보 입력 - 404 NOT FOUND ERROR")
+    void 공연정보가_없으면_예외를_던진다2() throws ParseException {
+        //given
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("2021-06-31");
+
+        //performanceRepository를 mock했으니 테스트 상황에서 원하는 결과를 새롭게 구현하는 코드.
+        //테스트가 돌아가는 동안에는 willReturn에서 반환하는 결과를 반드시 return하므로 PerformanceRepository를 의존하지 않고도 돌아가는 테스트코드가 완성
+        given(performanceRepository.findByStartDateGreaterThanEqualOrderByStartDateAsc(startDate))
+                .willReturn(new ArrayList<Performance>());
+        //when
+        //공연정보가 없는 경우 Service에서는 NOT FOUND ERROR 예외 호출
+        NotFoundDataException nfde = assertThrows(NotFoundDataException.class, () -> {
+            performanceService.getListPerformance(new PerformanceDto(null, startDate));
+        });
+        //then
+        String msg = nfde.getMessage();
+        assertThat(msg).isEqualTo(null);
+    }
+    //@TODO : 성공해야 하는데 두 테스트 메소드 모두 NotFoundDataException 발생,,
+    @Test
+    @DisplayName("[성공] 날짜를 정확히 입력한 경우")
+    void 공연정보가_있으면_응답한다1() throws ParseException {
+        //given
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("2021-06-20");
+
+        given(performanceRepository.findByStartDateGreaterThanEqualOrderByStartDateAsc(startDate))
+                .willReturn(new ArrayList<>());
+        //when
+        List<PerformanceResponse> result =  performanceService.getListPerformance(new PerformanceDto(null, startDate));
+
+        //then
+        assertThat(result.size()).isNotZero(); //2개
+    }
+    @Test
+    @DisplayName("[성공] 날짜, 제목을 정확히 입력한 경우")
+    void 공연정보가_있으면_응답한다2() throws ParseException {
+        //given
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = format.parse("2021-06-20");
+        String title = "국립무용단 <산조>";
+        List<Performance> temp = new ArrayList<>();
+        given(performanceRepository.findByTitleAndStartDateGreaterThanEqualOrderByStartDate(title, startDate))
+                .willReturn(temp);
+        //when
+        List<PerformanceResponse> result = performanceService.getListPerformance(new PerformanceDto(title, startDate));
+
+        //then
+        assertThat(result.size()).isNotZero();
+    }
+}

--- a/ticket/src/test/java/comento/backend/ticket/service/UserServiceTest.java
+++ b/ticket/src/test/java/comento/backend/ticket/service/UserServiceTest.java
@@ -1,0 +1,81 @@
+package comento.backend.ticket.service;
+
+import comento.backend.ticket.domain.User;
+import comento.backend.ticket.dto.UserDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+//given
+//when
+//then
+
+@SpringBootTest
+@Transactional
+public class UserServiceTest {
+    private final UserService userService;
+
+    @Autowired
+    public UserServiceTest(UserService userService) {
+        this.userService = userService;
+    }
+
+    @Test
+    @DisplayName("이메일을 입력하면 사용자 등록에 성공하여 DB에 저장한다.")
+    public void 이메일_등록_성공(){
+        //given
+        UserDto userDto = new UserDto("kimhyejung12@naver.com");
+
+        //when
+        Optional<User> result = Optional.ofNullable(userService.saveUser(userDto));
+
+        //then
+        result.ifPresent(selectUser -> {
+            System.out.println(selectUser.getId());
+            System.out.println(selectUser.getEmail());
+            System.out.println(selectUser.getCreateAt());
+        });
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 이메일을 입력하면 사용자 등록에 실패하여 예외를 반환한다.")
+    public void 이메일_등록_중복으로_인한_실패(){
+        //given
+        UserDto userDto = new UserDto("kimhyejung12@naver.com");
+        UserDto userDto2 = new UserDto("kimhyejung12@naver.com");
+
+        //when
+        Optional<User> result = Optional.ofNullable(userService.saveUser(userDto));
+        Optional<User> result2 = Optional.ofNullable(userService.saveUser(userDto2)); //error 409
+
+        //then
+        result.ifPresent(selectUser -> {
+            System.out.println(selectUser.getId());
+            System.out.println(selectUser.getEmail());
+            System.out.println(selectUser.getCreateAt());
+        });
+    }
+
+    @Test
+    @DisplayName("이메일 형태가 아닌 경우 or 타입 오류 발생 시 사용자 등록에 실패하여 예외가 반환한다.")
+    public void 이메일_등록_타입오류로_인한_실패(){ //@TODO : 에러가 발생해야 정상인데 성공 ... (Postman에서는 정상적으로 에러 발생)
+        //given
+        String email = "12"; //success?
+        UserDto userDto = new UserDto(email);
+
+        //when
+        Optional<User> result = Optional.ofNullable(userService.saveUser(userDto)); //error 400
+
+        //then
+        result.ifPresent(selectUser -> {
+            System.out.println(selectUser.getId());
+            System.out.println(selectUser.getEmail());
+            System.out.println(selectUser.getCreateAt());
+        });
+    }
+
+}


### PR DESCRIPTION
### 진행상황보고
1. 공연 좌석 정보를 공연명과 날짜를 이용하여 조회 가능
![1](https://user-images.githubusercontent.com/68772751/135559549-124e35bd-5303-47c9-910b-15405cc98d8c.JPG)
2. 공연 예약 가능
![2](https://user-images.githubusercontent.com/68772751/135559605-34643d65-4fa4-4499-b3ca-e436cc9d7fde.JPG)
  - DB에 존재하지 않는 유저는 예약 불가(401)
   ![401](https://user-images.githubusercontent.com/68772751/135559599-3383a9ee-963d-4867-88b6-d7badd1b7df5.JPG)
  - DB에 존재하지 않는 공연 정보는 에러 반환(404)
   ![404](https://user-images.githubusercontent.com/68772751/135559552-5ed45391-5a5e-40dc-a818-c90369d9f18b.JPG)
 
### 해결해야 할 문제
- 공연 좌석 정보 예약 시 **이미 예약된 좌석은 예약이 불가하도록** 만들어야 합니다. (레디스를 이용하려고 생각중입니다.)
![캡처](https://user-images.githubusercontent.com/68772751/135559669-e879c7d1-308f-4b4f-9982-ed2f980a0165.JPG)
- 동시성 문제를 해결하고, **예약 시 성공, 실패 상관 없이 예약 정보를 저장**하는 `BookingHistory`를 완성시켜야 합니다.
- 나의 예약 정보를 조회하는 코드를 완성시켜야 합니다.
----
### 질문
1. Mock 객체를 이용하여 유닛테스트를 진행하려고 하는데, 성공해야 하는 테스트 코드에도 NotFoundDataException을 발생시킵니다. 
2. `MockSeatServiceTest`의 경우, list.size()값이 0이지만, 실제로 테스트를 돌려보면 제대로 동작합니다 ........ 
3. `BookingService`에서 saveBookging 메소드로 예약 여부를 저장합니다. 이런 흐름이 맞는지 .... 잘 모르겠습니다. 
----
devlop 브랜치를 pull 받은 후에 push 했더니 이전 커밋들도 함께 올라가게 되었습니다 ... 죄송합니다.