### PR TITLE
[feat:#11] 좌석 예약 동시성 코드 추가, BookingHistory 관련 코드 이동, enum 패키지 생성

### DIFF
--- a/ticket/build.gradle
+++ b/ticket/build.gradle
@@ -27,6 +27,8 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'mysql:mysql-connector-java'
 	annotationProcessor 'org.projectlombok:lombok'
+	// redisson
+	implementation 'org.redisson:redisson-spring-boot-starter:3.16.3'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/ticket/src/main/java/comento/backend/ticket/controller/BookingController.java
+++ b/ticket/src/main/java/comento/backend/ticket/controller/BookingController.java
@@ -2,7 +2,6 @@ package comento.backend.ticket.controller;
 
 import comento.backend.ticket.config.SuccessCode;
 import comento.backend.ticket.config.SuccessResponse;
-import comento.backend.ticket.domain.Booking;
 import comento.backend.ticket.dto.BookingDto;
 import comento.backend.ticket.dto.BookingResponse;
 import comento.backend.ticket.dto.BookingResponseCreated;

--- a/ticket/src/main/java/comento/backend/ticket/domain/Seat.java
+++ b/ticket/src/main/java/comento/backend/ticket/domain/Seat.java
@@ -1,6 +1,6 @@
 package comento.backend.ticket.domain;
 
-import comento.backend.ticket.dto.SeatType;
+import comento.backend.ticket.emum.SeatType;
 import lombok.Builder;
 import lombok.Data;
 

--- a/ticket/src/main/java/comento/backend/ticket/dto/BookingDto.java
+++ b/ticket/src/main/java/comento/backend/ticket/dto/BookingDto.java
@@ -4,6 +4,8 @@ import comento.backend.ticket.domain.Booking;
 import comento.backend.ticket.domain.Performance;
 import comento.backend.ticket.domain.Seat;
 import comento.backend.ticket.domain.User;
+import comento.backend.ticket.emum.SeatType;
+import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 
@@ -28,6 +30,17 @@ public class BookingDto {
     private Integer seatNumber;
     private String price;
 
+    @Builder
+    public BookingDto(Long id, String title, Date startDate, String email, SeatType seatType, Integer seatNumber, String price) {
+        this.id = id;
+        this.title = title;
+        this.startDate = startDate;
+        this.email = email;
+        this.seatType = seatType;
+        this.seatNumber = seatNumber;
+        this.price = price;
+    }
+
     public Booking toEntity(final User user, final Performance performance, final Seat seat) {
         return Booking.builder()
                 .user(user)
@@ -35,5 +48,4 @@ public class BookingDto {
                 .seat(seat)
                 .build();
     }
-
 }

--- a/ticket/src/main/java/comento/backend/ticket/dto/BookingResponse.java
+++ b/ticket/src/main/java/comento/backend/ticket/dto/BookingResponse.java
@@ -1,5 +1,6 @@
 package comento.backend.ticket.dto;
 
+import comento.backend.ticket.emum.SeatType;
 import lombok.Data;
 
 import java.util.Date;

--- a/ticket/src/main/java/comento/backend/ticket/dto/BookingResponseCreated.java
+++ b/ticket/src/main/java/comento/backend/ticket/dto/BookingResponseCreated.java
@@ -1,5 +1,6 @@
 package comento.backend.ticket.dto;
 
+import comento.backend.ticket.emum.SeatType;
 import lombok.Data;
 
 @Data

--- a/ticket/src/main/java/comento/backend/ticket/dto/SeatDto.java
+++ b/ticket/src/main/java/comento/backend/ticket/dto/SeatDto.java
@@ -2,6 +2,7 @@ package comento.backend.ticket.dto;
 
 import comento.backend.ticket.domain.Performance;
 import comento.backend.ticket.domain.Seat;
+import comento.backend.ticket.emum.SeatType;
 import lombok.Builder;
 import lombok.Data;
 

--- a/ticket/src/main/java/comento/backend/ticket/dto/SeatResponse.java
+++ b/ticket/src/main/java/comento/backend/ticket/dto/SeatResponse.java
@@ -1,6 +1,7 @@
 package comento.backend.ticket.dto;
 
 import comento.backend.ticket.domain.Seat;
+import comento.backend.ticket.emum.SeatType;
 import lombok.Data;
 
 @Data

--- a/ticket/src/main/java/comento/backend/ticket/emum/SeatType.java
+++ b/ticket/src/main/java/comento/backend/ticket/emum/SeatType.java
@@ -1,4 +1,4 @@
-package comento.backend.ticket.dto;
+package comento.backend.ticket.emum;
 
 public enum SeatType {
     VIP,

--- a/ticket/src/main/java/comento/backend/ticket/repository/SeatRepository.java
+++ b/ticket/src/main/java/comento/backend/ticket/repository/SeatRepository.java
@@ -2,7 +2,7 @@ package comento.backend.ticket.repository;
 
 import comento.backend.ticket.domain.Performance;
 import comento.backend.ticket.domain.Seat;
-import comento.backend.ticket.dto.SeatType;
+import comento.backend.ticket.emum.SeatType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,6 +12,4 @@ import java.util.*;
 public interface SeatRepository extends JpaRepository<Seat, Long> {
     List<Seat> findByPerformance(Performance performance);
     Optional<Seat> findByPerformanceAndSeatTypeAndSeatNumber(Performance performance, SeatType seatType, Integer seatNumber);
-    //isBooking 여부 확인을 위해 사용
-    Optional<Seat> findByPerformanceAndSeatTypeAndSeatNumberAndIsBooking(Performance performance, SeatType seatType, Integer seatNumber, boolean isBooking);
 }

--- a/ticket/src/main/java/comento/backend/ticket/service/BookingHistoryService.java
+++ b/ticket/src/main/java/comento/backend/ticket/service/BookingHistoryService.java
@@ -1,9 +1,13 @@
 package comento.backend.ticket.service;
 
 import comento.backend.ticket.domain.BookingHistory;
+import comento.backend.ticket.domain.Performance;
+import comento.backend.ticket.domain.Seat;
+import comento.backend.ticket.domain.User;
 import comento.backend.ticket.dto.BookingHistoryDto;
 import comento.backend.ticket.repository.BookingHistoryRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class BookingHistoryService {
@@ -16,5 +20,27 @@ public class BookingHistoryService {
     public BookingHistory saveBookingHistory(final BookingHistoryDto bookingHistoryDto){
         BookingHistory bookingHistory = bookingHistoryDto.toEntity();
         return bookingHistoryRepository.save(bookingHistory);
+    }
+
+    public void saveBookingSucessLog(final User user, final Performance performance, final Seat seat) {
+        //booking의 성공 여부 history 저장
+        BookingHistoryDto bookingHistoryDto = BookingHistoryDto.builder()
+                .user(user)
+                .performance(performance)
+                .seat(seat)
+                .isSuccess(true)
+                .build();
+        saveBookingHistory(bookingHistoryDto);
+    }
+
+    public void saveBookingFailLog(final User user, final Performance performance, final Seat seat) {
+        //실패 여부 BookingHistory에 저장
+        BookingHistoryDto bookingHistoryDto = BookingHistoryDto.builder()
+                .user(user)
+                .performance(performance)
+                .seat(seat)
+                .isSuccess(false)
+                .build();
+        saveBookingHistory(bookingHistoryDto);
     }
 }

--- a/ticket/src/main/java/comento/backend/ticket/service/BookingService.java
+++ b/ticket/src/main/java/comento/backend/ticket/service/BookingService.java
@@ -4,46 +4,70 @@ import comento.backend.ticket.config.customException.NotFoundDataException;
 import comento.backend.ticket.domain.*;
 import comento.backend.ticket.dto.*;
 import comento.backend.ticket.repository.BookingRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
-import java.util.stream.Collectors;
+import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Service
 public class BookingService {
+    private static final int WAIT_TIME = 1;
+    private static final int LEASE_TIME = 1;
+    private static final String SEAT_LOCK = "seat_lock";
+
     private final BookingRepository bookingRepository;
     private final PerformanceService performanceService;
     private final BookingHistoryService bookingHistoryService;
     private final UserService userService;
     private final SeatService seatService;
+    private final RedissonClient redissonClient;
 
     public BookingService(BookingRepository bookingRepository, PerformanceService performanceService,
                           BookingHistoryService bookingHistoryService, UserService userService,
-                          SeatService seatService) {
+                          SeatService seatService, RedissonClient redissonClient) {
         this.bookingRepository = bookingRepository;
         this.performanceService = performanceService;
         this.bookingHistoryService = bookingHistoryService;
         this.userService = userService;
         this.seatService = seatService;
+        this.redissonClient = redissonClient;
     }
 
-    // @TODO : 동시성 문제 해결해야 함
-    //예약 정보를 booking에 저장하고, Seat 정보에는 is_booking을 true로 변경
-    @Transactional
-    public Booking saveBookging(final BookingDto reqBooking){
-        final User user = userService.getUser(reqBooking.getEmail());
-        final Performance performance = performanceService.getPerformance(reqBooking.getId(), reqBooking.getTitle());
-        final Seat seat = seatService.getIsBooking(user, performance, reqBooking.getSeatType(), reqBooking.getSeatNumber(), false); //false라면 예약 가능
+    public Booking saveBookging(final BookingDto reqBooking) {
+        RLock lock = redissonClient.getLock(SEAT_LOCK);
+        lock.lock(LEASE_TIME, TimeUnit.SECONDS);
 
-        //seat 테이블의 is_booking 칼럼을 true로 update
-        updateSeat(seat, performance, reqBooking);
+        Booking booking = null;
+        try {
+            if (!(lock.tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS))) {
+                log.info("lock 획득 실패");
+                throw new RuntimeException("Rock fail!");
+            }
+            log.info("lock 획득");
+            final User user = userService.getUser(reqBooking.getEmail());
+            final Performance performance = performanceService.getPerformance(reqBooking.getId(), reqBooking.getTitle());
+            final Seat seat = seatService.getIsBooking(user, performance, reqBooking.getSeatType(), reqBooking.getSeatNumber()); //false라면 예약 가능
 
-        //seat의 값이 있다면, booking 가능
-        saveBookingSucessLog(user, performance, seat);
+            //seat 테이블의 is_booking 칼럼을 true로 update
+            updateSeat(seat, performance, reqBooking);
 
-        //booking 여부 insert
-        Booking booking = reqBooking.toEntity(user, performance, seat);
+            //seat의 값이 있다면, booking 가능
+            bookingHistoryService.saveBookingSucessLog(user, performance, seat);
+
+            //booking 여부 insert
+            booking = reqBooking.toEntity(user, performance, seat);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        } finally {
+            lock.unlock();
+            log.info("lock 반납");
+        }
+
         return bookingRepository.save(booking);
     }
 
@@ -58,22 +82,11 @@ public class BookingService {
         seatService.updateSeat(seatDto);
     }
 
-    private void saveBookingSucessLog(final User user, final Performance performance, final Seat seat) {
-        //booking의 성공 여부 history 저장
-        BookingHistoryDto bookingHistoryDto = BookingHistoryDto.builder()
-                        .user(user)
-                        .performance(performance)
-                        .seat(seat)
-                        .isSuccess(true)
-                        .build();
-        bookingHistoryService.saveBookingHistory(bookingHistoryDto);
-    }
-
     @Transactional(readOnly = true)
-    public List<BookingResponse> getMyBooking(String email){
+    public List<BookingResponse> getMyBooking(String email) {
         User user = userService.getUser(email);
         List<BookingResponse> result = bookingRepository.findMyBooking(true, user.getEmail());
-        if(result.isEmpty()){
+        if (result.isEmpty()) {
             throw new NotFoundDataException();
         }
         return result;


### PR DESCRIPTION
## 진행상황보고
1. enum 패키지를 생성하여 dto에서 분리하였습니다.
2. redisson을 이용하여 분산락 구현하였습니다.
3. SeatService에서 getIsBooking 시 Seat 테이블의 is_booking 여부가 T/F 상관없이 seat_id를 가져오기 위해 관련 메소드를 수정하였습니다.
4. 기존에 예약 실패 시 저장되지 않는 문제를 @Transcational 어노테이션을 제거하여 해결하고, 관련 저장 메소드를 BookingHistoryService로 옮겼습니다.

## 질문
redisson을 이용하여 분산락을 구현할 경우, @Transcational 은 동시에 동작할 수 없다고 하여 어노테이션을 삭제했습니다.
근데 이렇게 삭제할 경우, 지난 번에 피드백 해주신 acid가 보장될지 의문입니다..!! 
